### PR TITLE
Instantiated ConfigMap and Secret labels

### DIFF
--- a/config/crd/bases/lib.projectsveltos.io_eventbasedaddons.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventbasedaddons.yaml
@@ -194,7 +194,6 @@ spec:
                   required:
                   - kind
                   - name
-                  - namespace
                   type: object
                 type: array
               sourceClusterSelector:

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -66,6 +66,11 @@ var (
 	UnstructuredToTyped           = unstructuredToTyped
 )
 
+const (
+	ReferencedResourceNamespaceLabel = referencedResourceNamespaceLabel
+	ReferencedResourceNameLabel      = referencedResourceNameLabel
+)
+
 // fetcher
 var (
 	GetConfigMap             = getConfigMap

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -200,7 +200,6 @@ spec:
                   required:
                   - kind
                   - name
-                  - namespace
                   type: object
                 type: array
               sourceClusterSelector:

--- a/test/fv/instantiate_one_for_all_test.go
+++ b/test/fv/instantiate_one_for_all_test.go
@@ -111,6 +111,11 @@ var _ = Describe("Instantiate one ClusterProfile for all resources", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      randomString(),
+				// Mark resource as template so instantiateReferencedPolicies
+				// will generate a new one in projectsveltos namespace
+				Annotations: map[string]string{
+					"projectsveltos.io/template": "ok",
+				},
 			},
 			Data: map[string]string{
 				"ingress": fmt.Sprintf(ingress, serviceNamespace),

--- a/test/fv/instantiate_test.go
+++ b/test/fv/instantiate_test.go
@@ -109,6 +109,11 @@ var _ = Describe("Instantiate one ClusterProfile per resource", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      randomString(),
+				// Mark resource as template so instantiateReferencedPolicies
+				// will generate a new one in projectsveltos namespace
+				Annotations: map[string]string{
+					"projectsveltos.io/template": "ok",
+				},
 			},
 			Data: map[string]string{
 				"calico": networkPolicy,


### PR DESCRIPTION
An EventBasedAddOn can reference ConfigMaps and Secrets. When an event happens, the EventBasedAddOn controller creates one or more ClusterProfile (depending on its configuration).
Those referenced ConfigMaps and Secrets can be expressed as template and instantiated using values from resources in managed clusters that generated the event.

Each ConfigMap, Secret referenced by EventBasedAddOn gets instantiated in the projectsveltos namespace. And the created ClusterProfile references that.

When creating a ConfigMap or Secret, labels are added. Before this PR labels only contained information on the managed cluster and the EventBasedAddOn instance name.

This PR adds two more labels containing the original ConfigMap or Secret namespace and name.
The labels are also used to generated the name of the instantiated ConfigMap or Secret.

This fixes #94 
 
Such issues consisted that only one ConfigMap or Secret was created even if the EventBasedAddOn was referencing more than one ConfigMap or more than one Secret. Issue was tied to generated name which did not contain any info regarding the original referenced object.