### PR TITLE
Fix undeploy path

### DIFF
--- a/controllers/eventbasedaddon_deployer.go
+++ b/controllers/eventbasedaddon_deployer.go
@@ -163,10 +163,9 @@ func (r *EventBasedAddOnReconciler) undeployEventBasedAddOn(ctx context.Context,
 
 	var err error
 	for i := range resource.Status.ClusterInfo {
-		var shardMatch bool
-		shardMatch, err = r.isClusterAShardMatch(ctx, &resource.Status.ClusterInfo[i])
-		if err != nil {
-			return err
+		shardMatch, tmpErr := r.isClusterAShardMatch(ctx, &resource.Status.ClusterInfo[i])
+		if tmpErr != nil {
+			err = tmpErr
 		}
 
 		if !shardMatch && resource.Status.ClusterInfo[i].Status != libsveltosv1alpha1.SveltosStatusRemoved {
@@ -177,7 +176,7 @@ func (r *EventBasedAddOnReconciler) undeployEventBasedAddOn(ctx context.Context,
 
 		c := &resource.Status.ClusterInfo[i].Cluster
 
-		_, tmpErr := r.removeEventBasedAddOn(ctx, eScope, c, f, logger)
+		_, tmpErr = r.removeEventBasedAddOn(ctx, eScope, c, f, logger)
 		if tmpErr != nil {
 			err = tmpErr
 		}


### PR DESCRIPTION
When using cluster sharding, when reconciling EventBasedAddOn delete path, if a cluster is not a shard match, treat it as an error. This will make sure finalizer is not remove hence giving a chance to the deployment matching the shard to clean up.