### PR TITLE
Fix an error with multiple cluster shards

### DIFF
--- a/controllers/eventbasedaddon_controller.go
+++ b/controllers/eventbasedaddon_controller.go
@@ -193,6 +193,7 @@ func (r *EventBasedAddOnReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// changes.
 	defer func() {
 		if err := eventBasedAddOnScope.Close(ctx); err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to update: %v", err))
 			reterr = err
 		}
 	}()

--- a/controllers/eventbasedaddon_deployer.go
+++ b/controllers/eventbasedaddon_deployer.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -123,6 +124,12 @@ func (r *EventBasedAddOnReconciler) deployEventBasedAddOn(ctx context.Context, e
 			clusterInfo = c
 			if clusterInfo.Status != libsveltosv1alpha1.SveltosStatusProvisioned {
 				allProcessed = false
+			}
+			// This is a required parameter. It is set by the deployment matching the
+			// cluster shard. if not set yet, set it to empty
+			if clusterInfo.Hash == nil {
+				str := base64.StdEncoding.EncodeToString([]byte("empty"))
+				clusterInfo.Hash = []byte(str)
 			}
 		} else {
 			clusterInfo, err = r.processEventBasedAddOn(ctx, eScope, &c.Cluster, f, logger)


### PR DESCRIPTION
ClusterInfo Hash is a required parameter. For a given cluster matching an EventBasedAddon this is set by the Sveltos deployment matching the cluster shard.
Other deployment will simply skip such ClusterInfo. Since this is a required field, if deployment matching the shard it has not processed the EventBasedAddOn instance, any other Sveltos deployment will set it to ```empty``` if not set already.