### PR TITLE
EventTrigger: referenced resource names as template

### DIFF
--- a/controllers/eventtrigger_controller_test.go
+++ b/controllers/eventtrigger_controller_test.go
@@ -378,7 +378,7 @@ var _ = Describe("EventTrigger: Reconciler", func() {
 		})
 		Expect(err).To(BeNil())
 
-		controllers.UpdateMaps(&reconciler, resourceScope)
+		Expect(controllers.UpdateMaps(&reconciler, resourceScope, logger)).To(Succeed())
 
 		clusterInfo := &corev1.ObjectReference{Namespace: clusterNamespace, Name: clusterName,
 			Kind: libsveltosv1beta1.SveltosClusterKind, APIVersion: libsveltosv1beta1.GroupVersion.String()}
@@ -461,7 +461,7 @@ var _ = Describe("EventTrigger: Reconciler", func() {
 		})
 		Expect(err).To(BeNil())
 
-		controllers.UpdateReferencedResourceMap(&reconciler, resourceScope)
+		Expect(controllers.UpdateReferencedResourceMap(&reconciler, resourceScope)).To(Succeed())
 
 		eventTriggerName := types.NamespacedName{Name: resourceScope.Name()}
 		v, ok := reconciler.EventTriggerMap[eventTriggerName]

--- a/controllers/eventtrigger_deployer_test.go
+++ b/controllers/eventtrigger_deployer_test.go
@@ -834,9 +834,17 @@ var _ = Describe("EventTrigger deployer", func() {
 						RepositoryURL:    randomString(),
 						ReleaseNamespace: "{{ .MatchingResource.Namespace }}",
 						ReleaseName:      randomString(),
-						ChartName:        randomString(),
+						ChartName:        randomString() + "{{ .Cluster.metadata.name }}",
 						ChartVersion:     randomString(),
 						HelmChartAction:  configv1beta1.HelmChartActionInstall,
+					},
+				},
+				KustomizationRefs: []configv1beta1.KustomizationRef{
+					{
+						Namespace: "{{ .MatchingResource.Namespace }}",
+						Name:      randomString() + "{{ .Cluster.metadata.name }}",
+						Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+						Path:      randomString() + "{{ .Cluster.metadata.name }}" + "{{ .MatchingResource.Namespace }}",
 					},
 				},
 			},
@@ -869,6 +877,7 @@ var _ = Describe("EventTrigger deployer", func() {
 			Expect(clusterProfiles.Items[i].Spec.ClusterRefs[0].Name).To(Equal(clusterName))
 			Expect(clusterProfiles.Items[i].Spec.ClusterRefs[0].Kind).To(Equal("Cluster"))
 			Expect(len(clusterProfiles.Items[i].Spec.HelmCharts)).To(Equal(1))
+			Expect(len(clusterProfiles.Items[i].Spec.KustomizationRefs)).To(Equal(1))
 		}
 	})
 


### PR DESCRIPTION
EventTrigger can reference resources in the PolicyRefs section:

- namespace of each of those resources can either be set or left
empty (in which case the cluster's namespace will be used);
- name of each of those resources can be expressed as a template
using `.Cluster.metadata.namespace`, `.Cluster.metadata.name` and
`.Cluster.metedata.kind`

HelmCharts are also instantiated. If an Helm chart is referencing
one or more ConfigMap/Secret instances via ValuesFrom, those are
instantiated if referenced resource contains the annotation
`projectsveltos.io/template`

Same applies to KustomizationRefs, which are also instantiated.
If a KustomizationRef is referencing one or more ConfigMap/Secret
instances via ValuesFrom, those are instantiated if referenced
resource contains the annotation `projectsveltos.io/template`