### PR TITLE
(feat) when referenced resource does not exist, report an error

### DIFF
--- a/controllers/fetcher.go
+++ b/controllers/fetcher.go
@@ -151,7 +151,8 @@ func fetchPolicyRefs(ctx context.Context, c client.Client, e *v1beta1.EventTrigg
 			if apierrors.IsNotFound(err) {
 				logger.V(logs.LogInfo).Info(fmt.Sprintf("%s %s/%s does not exist yet",
 					policyRef.Kind, namespace, referencedName))
-				continue
+				return nil, nil, fmt.Errorf("referenced %s %s/%s does not exist",
+					policyRef.Kind, namespace, string(referencedName))
 			}
 			return nil, nil, err
 		}


### PR DESCRIPTION
This is a behavior change. But it is required as most of the time such errors are typos. And nothing gets deployed as result.

Fixes #273 