### PR TITLE
Use context with timeout when checking compatibility checks

### DIFF
--- a/controllers/eventreport_collection.go
+++ b/controllers/eventreport_collection.go
@@ -263,7 +263,10 @@ func collectAndProcessEventReportsFromCluster(ctx context.Context, c client.Clie
 		return err
 	}
 
-	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, remoteClient, version) {
+	const ten = 10
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, ten*time.Second)
+	defer cancel()
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctxWithTimeout, remoteClient, version) {
 		msg := "compatibility checks failed"
 		logger.V(logs.LogDebug).Info(msg)
 		return errors.New(msg)


### PR DESCRIPTION
If Cluster is not reachable anymore, default timeout is too long