### PR TITLE
(bug) allows CloudEventAction to be a template

### DIFF
--- a/api/v1beta1/eventtrigger_types.go
+++ b/api/v1beta1/eventtrigger_types.go
@@ -261,6 +261,7 @@ type EventTriggerSpec struct {
 	// CloudEvents with the same source and subject are considered related and represent
 	// different states of the same entity. This field specifies whether to create or
 	// delete the associated Kubernetes resources.
+	// This can be expressed as a template and instantiated at run time using CloudEvent
 	// +kubebuilder:default:=Create
 	// +optional
 	CloudEventAction CloudEventAction `json:"cloudEventAction,omitempty"`

--- a/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
@@ -948,6 +948,7 @@ spec:
                   CloudEvents with the same source and subject are considered related and represent
                   different states of the same entity. This field specifies whether to create or
                   delete the associated Kubernetes resources.
+                  This can be expressed as a template and instantiated at run time using CloudEvent
                 type: string
               clusterSetRefs:
                 description: SetRefs identifies referenced ClusterSets. Name of the

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -963,6 +963,7 @@ spec:
                   CloudEvents with the same source and subject are considered related and represent
                   different states of the same entity. This field specifies whether to create or
                   delete the associated Kubernetes resources.
+                  This can be expressed as a template and instantiated at run time using CloudEvent
                 type: string
               clusterSetRefs:
                 description: SetRefs identifies referenced ClusterSets. Name of the


### PR DESCRIPTION
CloudEventAction can be expressed as a template. So whether to create or delete can be a function of CloudEvent properties.

For instance

````yaml
apiVersion: lib.projectsveltos.io/v1beta1
kind: EventSource
metadata:
  name: user-operation
spec:
  messagingMatchCriteria:
  - subject: "user-operation"
    cloudEventSource: "auth.example.com/operation"
---
apiVersion: lib.projectsveltos.io/v1beta1
kind: EventTrigger
metadata:
  name: manage-namespace
spec:
  sourceClusterSelector:
    matchLabels:
      env: fv
  eventSourceName: user-operation
  oneForEvent: true
  syncMode: ContinuousWithDriftDetection
  cloudEventAction: "{{ if eq .CloudEvent.type 'auth.example.com.logout' }}Delete{{ else }}Create{{ end }}"
  policyRefs:
  - name: namespace
    namespace: default
    kind: ConfigMap
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: namespace
  namespace: default
  annotations:
    projectsveltos.io/instantiate: ok
data:
  namespace.yaml: |
    kind: Namespace
    apiVersion: v1
    metadata:
      name: {{ .CloudEvent.subject }}
```

when CloudEvent is for instance

```
CLOUDEVENT_JSON=$(cat << EOF
{
  "specversion": "1.0",
  "type": "auth.example.com.login",
  "source": "auth.example.com/operation",
  "id": "10001",
  "subject": "mgianluc",
  "datacontenttype": "application/json",
  "data": {
    "message": "Hello from bash!"
  }
}
EOF
)
```
namespace is created.

When CloudEvent is

```
CLOUDEVENT_JSON=$(cat << EOF
{
  "specversion": "1.0",
  "type": "auth.example.com.logòut",
  "source": "auth.example.com/operation",
  "id": "10001",
  "subject": "mgianluc",
  "datacontenttype": "application/json",
  "data": {
    "message": "Hello from bash!"
  }
}
EOF
)
```

namespace is deleted.

This PR also fixes this [bug](https://github.com/projectsveltos/sveltos/issues/465).