### PR TITLE
(bug) Mark OneForEvent as immutable field

### DIFF
--- a/api/v1beta1/eventtrigger_types.go
+++ b/api/v1beta1/eventtrigger_types.go
@@ -91,6 +91,7 @@ type EventTriggerSpec struct {
 	// EventSource. OneForEvent indicates whether a ClusterProfile for all
 	// resource (OneForEvent = false) or one per resource (OneForEvent = true)
 	// needs to be creted.
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +optional
 	OneForEvent bool `json:"oneForEvent,omitempty"`
 

--- a/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
@@ -1638,6 +1638,9 @@ spec:
                   resource (OneForEvent = false) or one per resource (OneForEvent = true)
                   needs to be creted.
                 type: boolean
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               patches:
                 description: |-
                   Define additional Kustomize inline Patches applied for all resources on this profile

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1653,6 +1653,9 @@ spec:
                   resource (OneForEvent = false) or one per resource (OneForEvent = true)
                   needs to be creted.
                 type: boolean
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               patches:
                 description: |-
                   Define additional Kustomize inline Patches applied for all resources on this profile


### PR DESCRIPTION
Once set, if user try to change it

```
The EventTrigger "xxxx" is invalid: spec.oneForEvent: Invalid value: "boolean": Value is immutable
```

Fixes [466](https://github.com/projectsveltos/sveltos/issues/466)