### PR TITLE
(feat) allow setting dependsOn on EventTrigger

### DIFF
--- a/api/v1beta1/eventtrigger_types.go
+++ b/api/v1beta1/eventtrigger_types.go
@@ -206,6 +206,12 @@ type EventTriggerSpec struct {
 	// +optional
 	Reloader bool `json:"reloader,omitempty"`
 
+	// DependsOn specifies a list of other ClusterProfiles that this instance depends on.
+	// In any managed cluster that matches this ClusterProfile, the add-ons and applications
+	// defined in this instance will not be deployed until all add-ons and applications in the
+	// ClusterProfiles listed as dependencies are deployed.
+	DependsOn []string `json:"dependsOn,omitempty"`
+
 	// TemplateResourceRefs is a list of resource to collect from the management cluster.
 	// Those resources' values will be used to instantiate templates contained in referenced
 	// PolicyRefs and Helm charts

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *EventTriggerSpec) DeepCopyInto(out *EventTriggerSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
+	if in.DependsOn != nil {
+		in, out := &in.DependsOn, &out.DependsOn
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TemplateResourceRefs != nil {
 		in, out := &in.TemplateResourceRefs, &out.TemplateResourceRefs
 		*out = make([]apiv1beta1.TemplateResourceRef, len(*in))

--- a/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
@@ -100,6 +100,15 @@ spec:
                   This field will be directly transferred to the ClusterProfile Spec
                   generated in response to events.
                 type: boolean
+              dependsOn:
+                description: |-
+                  DependsOn specifies a list of other ClusterProfiles that this instance depends on.
+                  In any managed cluster that matches this ClusterProfile, the add-ons and applications
+                  defined in this instance will not be deployed until all add-ons and applications in the
+                  ClusterProfiles listed as dependencies are deployed.
+                items:
+                  type: string
+                type: array
               destinationClusterSelector:
                 description: |-
                   DestinationClusterSelector identifies the cluster where add-ons will be deployed.

--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -1120,15 +1120,15 @@ func instantiateClusterProfileSpecPerAllResource(ctx context.Context, c client.C
 	clusterType libsveltosv1beta1.ClusterType, eventTrigger *v1beta1.EventTrigger, labels map[string]string,
 	objects *currentObjects, logger logr.Logger) (*configv1beta1.Spec, error) {
 
-	clusterProfileSpec := configv1beta1.Spec{}
+	clusterProfileSpec := getClusterProfileSpec(eventTrigger)
 
 	templateName := getTemplateName(clusterNamespace, clusterName, eventTrigger.Name)
-	err := setTemplateResourceRefs(&clusterProfileSpec, templateName, objects.Cluster, objects, eventTrigger, logger)
+	err := setTemplateResourceRefs(clusterProfileSpec, templateName, objects.Cluster, objects, eventTrigger, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	setClusterSelector(&clusterProfileSpec, clusterNamespace, clusterName, clusterType, eventTrigger)
+	setClusterSelector(clusterProfileSpec, clusterNamespace, clusterName, clusterType, eventTrigger)
 
 	instantiateHelmChartsWithResources, err := instantiateHelmChartsWithAllResources(ctx, c, eventTrigger,
 		clusterNamespace, templateName, eventTrigger.Spec.HelmCharts, objects, labels, logger)
@@ -1146,13 +1146,13 @@ func instantiateClusterProfileSpecPerAllResource(ctx context.Context, c client.C
 
 	clusterProfileSpec.DriftExclusions = eventTrigger.Spec.DriftExclusions
 
-	err = setPolicyRefs(ctx, c, &clusterProfileSpec, templateName, clusterNamespace, clusterName, clusterType,
+	err = setPolicyRefs(ctx, c, clusterProfileSpec, templateName, clusterNamespace, clusterName, clusterType,
 		objects, eventTrigger, labels, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	return &clusterProfileSpec, nil
+	return clusterProfileSpec, nil
 }
 
 func setTemplateResourceRefs(clusterProfileSpec *configv1beta1.Spec, templateName string, clusterContent map[string]interface{},
@@ -2715,5 +2715,6 @@ func getClusterProfileSpec(eventTrigger *v1beta1.EventTrigger) *configv1beta1.Sp
 		ExtraLabels:          eventTrigger.Spec.ExtraLabels,
 		ExtraAnnotations:     eventTrigger.Spec.ExtraAnnotations,
 		DriftExclusions:      eventTrigger.Spec.DriftExclusions,
+		DependsOn:            eventTrigger.Spec.DependsOn,
 	}
 }

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -104,6 +104,15 @@ spec:
                   This field will be directly transferred to the ClusterProfile Spec
                   generated in response to events.
                 type: boolean
+              dependsOn:
+                description: |-
+                  DependsOn specifies a list of other ClusterProfiles that this instance depends on.
+                  In any managed cluster that matches this ClusterProfile, the add-ons and applications
+                  defined in this instance will not be deployed until all add-ons and applications in the
+                  ClusterProfiles listed as dependencies are deployed.
+                items:
+                  type: string
+                type: array
               destinationClusterSelector:
                 description: |-
                   DestinationClusterSelector identifies the cluster where add-ons will be deployed.


### PR DESCRIPTION
Feature: Introduce _dependsOn_ field for EventTrigger. This feature allows specifying dependencies that must be deployed prior to the resources triggered by the event, ensuring proper execution order.