### PR TITLE
(feat) in FV always adds annotations to EventSources

### DIFF
--- a/test/fv/cloudevent_test.go
+++ b/test/fv/cloudevent_test.go
@@ -63,6 +63,9 @@ var _ = Describe("CloudEvents", func() {
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namePrefix + randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				MessagingMatchCriteria: []libsveltosv1beta1.MessagingMatchCriteria{

--- a/test/fv/clusterset_test.go
+++ b/test/fv/clusterset_test.go
@@ -65,6 +65,9 @@ var _ = Describe("Reference ClusterSet", func() {
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{

--- a/test/fv/generators_test.go
+++ b/test/fv/generators_test.go
@@ -90,6 +90,9 @@ var _ = Describe("Generators", func() {
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{

--- a/test/fv/instantiate_helmchart_test.go
+++ b/test/fv/instantiate_helmchart_test.go
@@ -49,6 +49,9 @@ var _ = Describe("Instantiate one ClusterProfile per resource. Instantiate and d
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{

--- a/test/fv/instantiate_one_for_all_test.go
+++ b/test/fv/instantiate_one_for_all_test.go
@@ -95,6 +95,9 @@ var _ = Describe("Instantiate one ClusterProfile for all resources", func() {
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{

--- a/test/fv/instantiate_test.go
+++ b/test/fv/instantiate_test.go
@@ -95,6 +95,9 @@ var _ = Describe("Instantiate one ClusterProfile per resource", func() {
 		eventSource := libsveltosv1beta1.EventSource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
+				Annotations: map[string]string{
+					randomString(): randomString(),
+				},
 			},
 			Spec: libsveltosv1beta1.EventSourceSpec{
 				ResourceSelectors: []libsveltosv1beta1.ResourceSelector{


### PR DESCRIPTION
Sveltos logic on whether an EventSource should be processed by sveltos-agent or not is based on annotations.
Setting annotations makes sure this part is correctly set.