### PR TITLE
feat: support full cluster-based templating for referenced resources

### DIFF
--- a/controllers/eventtrigger_deployer_test.go
+++ b/controllers/eventtrigger_deployer_test.go
@@ -1212,9 +1212,17 @@ var _ = Describe("EventTrigger deployer", func() {
 			},
 		}
 
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: namespace,
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
+
 		clusterRef := &corev1.ObjectReference{
 			Namespace:  namespace,
-			Name:       randomString(),
+			Name:       cluster.Name,
 			Kind:       "Cluster",
 			APIVersion: clusterv1.GroupVersion.String(),
 		}
@@ -1235,6 +1243,9 @@ var _ = Describe("EventTrigger deployer", func() {
 
 		Expect(testEnv.Client.Create(context.TODO(), eventTrigger)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv.Client, eventTrigger)).To(Succeed())
+
+		Expect(testEnv.Client.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
 
 		object := &controllers.CurrentObject{
 			MatchingResource: corev1.ObjectReference{
@@ -1349,9 +1360,17 @@ var _ = Describe("EventTrigger deployer", func() {
 			},
 		}
 
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: namespace,
+			},
+		}
+		Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
+
 		clusterRef := &corev1.ObjectReference{
 			Namespace:  namespace,
-			Name:       randomString(),
+			Name:       cluster.Name,
 			Kind:       "Cluster",
 			APIVersion: clusterv1.GroupVersion.String(),
 		}
@@ -1383,6 +1402,9 @@ var _ = Describe("EventTrigger deployer", func() {
 
 		Expect(testEnv.Create(context.TODO(), eventTrigger)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv, eventTrigger)).To(Succeed())
+
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv, cluster)).To(Succeed())
 
 		httpsService1 := `apiVersion: v1
 kind: Service

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v0.53.0
-	github.com/projectsveltos/libsveltos v0.53.0
+	github.com/projectsveltos/libsveltos v0.53.1-0.20250506070210-ef75a78e70a1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/text v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/projectsveltos/addon-controller v0.53.0 h1:c5m0VYlE0x6WGnXFQHDq0/jd/MAQxUDFV5GYxyhMA7k=
 github.com/projectsveltos/addon-controller v0.53.0/go.mod h1:8vo6UT/SniOJuwNrbbrHAwD8EtnPRjpb5FpnTpxI+JQ=
-github.com/projectsveltos/libsveltos v0.53.0 h1:TiMMujh6kX6evFYk1XrPrwQhiv0pNSxuwRmGeGcGEiM=
-github.com/projectsveltos/libsveltos v0.53.0/go.mod h1:sqZMoHeBgXY6cMIRrByGsdZxpOmwdK+p/H3G81yZ6q0=
+github.com/projectsveltos/libsveltos v0.53.1-0.20250506070210-ef75a78e70a1 h1:62mLgYOrZiqhMD6vc8JcndMs8obZpq+tfvNePsi774Y=
+github.com/projectsveltos/libsveltos v0.53.1-0.20250506070210-ef75a78e70a1/go.mod h1:sqZMoHeBgXY6cMIRrByGsdZxpOmwdK+p/H3G81yZ6q0=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=


### PR DESCRIPTION
Referenced resource namespace/name can be expressed as template (same as before) and will be instantiated using full cluster resource. Before this PR only cluster namespace/names/kind were used to instantiate namespace and name.