### PR TITLE
(feat) add destinationCluster

### DIFF
--- a/api/v1beta1/eventtrigger_types.go
+++ b/api/v1beta1/eventtrigger_types.go
@@ -94,6 +94,21 @@ type EventTriggerSpec struct {
 	// +optional
 	ClusterSetRefs []string `json:"clusterSetRefs,omitempty"`
 
+	// DestinationClusterSelector identifies the cluster where add-ons will be deployed.
+	// By default, this is nil and add-ons will be deployed in the very same cluster the
+	// event happened.
+	// If DestinationClusterSelector is set though, when an event happens in any of the
+	// cluster identified by SourceClusterSelector, add-ons will be deployed in each of
+	// the cluster indentified by DestinationClusterSelector.
+	// +optional
+	DestinationClusterSelector libsveltosv1beta1.Selector `json:"destinationClusterSelector,omitempty"`
+
+	// DestinationCluster identifies a specific cluster (by name) to deploy add-ons to.
+	// This field is templatable, allowing dynamic values based on the event context.
+	// Cannot be set if DestinationClusterSelector is set.
+	// +optional
+	DestinationCluster *corev1.ObjectReference `json:"destinationCluster,omitempty"`
+
 	// Multiple resources in a managed cluster can be a match for referenced
 	// EventSource. OneForEvent indicates whether a ClusterProfile for all
 	// resource (OneForEvent = false) or one per resource (OneForEvent = true)
@@ -112,15 +127,6 @@ type EventTriggerSpec struct {
 	// - cluster type: .Cluster.kind
 	// +kubebuilder:validation:MinLength=1
 	EventSourceName string `json:"eventSourceName"`
-
-	// DestinationClusterSelector identifies the cluster where add-ons will be deployed.
-	// By default, this is nil and add-ons will be deployed in the very same cluster the
-	// event happened.
-	// If DestinationClusterSelector is set though, when an event happens in any of the
-	// cluster identified by SourceClusterSelector, add-ons will be deployed in each of
-	// the cluster indentified by DestinationClusterSelector.
-	// +optional
-	DestinationClusterSelector libsveltosv1beta1.Selector `json:"destinationClusterSelector,omitempty"`
 
 	// The ConfigMapGenerator field references ConfigMaps containing templates.
 	// These referenced ConfigMaps will be dynamically instantiated in the management cluster

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -98,6 +98,11 @@ func (in *EventTriggerSpec) DeepCopyInto(out *EventTriggerSpec) {
 		copy(*out, *in)
 	}
 	in.DestinationClusterSelector.DeepCopyInto(&out.DestinationClusterSelector)
+	if in.DestinationCluster != nil {
+		in, out := &in.DestinationCluster, &out.DestinationCluster
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	if in.ConfigMapGenerator != nil {
 		in, out := &in.ConfigMapGenerator, &out.ConfigMapGenerator
 		*out = make([]GeneratorReference, len(*in))

--- a/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
+++ b/config/crd/bases/lib.projectsveltos.io_eventtriggers.yaml
@@ -116,6 +116,52 @@ spec:
                 items:
                   type: string
                 type: array
+              destinationCluster:
+                description: |-
+                  DestinationCluster identifies a specific cluster (by name) to deploy add-ons to.
+                  This field is templatable, allowing dynamic values based on the event context.
+                  Cannot be set if DestinationClusterSelector is set.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               destinationClusterSelector:
                 description: |-
                   DestinationClusterSelector identifies the cluster where add-ons will be deployed.

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -120,6 +120,52 @@ spec:
                 items:
                   type: string
                 type: array
+              destinationCluster:
+                description: |-
+                  DestinationCluster identifies a specific cluster (by name) to deploy add-ons to.
+                  This field is templatable, allowing dynamic values based on the event context.
+                  Cannot be set if DestinationClusterSelector is set.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               destinationClusterSelector:
                 description: |-
                   DestinationClusterSelector identifies the cluster where add-ons will be deployed.


### PR DESCRIPTION
There are scenarios where an event in one cluster (like a management cluster) necessitates deploying resources to different cluster, a specific one. This PR introduces a new field in EventTrigger: __destinationCluster__

This field is a corev1.ObjectReference and can be expressed as template. If defined, Sveltos will first instantiate it (using both Resource and source cluster data), then set the ClusterProfile.Spec.ClusterRefs.

For instance

````yaml
apiVersion: lib.projectsveltos.io/v1beta1
kind: EventTrigger
metadata:
  name: service-network-policy
spec:
  sourceClusterSelector:
    matchLabels:
      type: mgmt
  destinationCluster:
    name: "{{ .Resource.metadata.name }}"
    namespace: "{{ .Resource.metadata.namespace }}"
    kind: SveltosCluster
    apiVersion: lib.projectsveltos.io/v1beta1
```

a possible outcome for the ClusterProfile generated when an event happens:

```
  apiVersion: config.projectsveltos.io/v1beta1
  kind: ClusterProfile
  metadata:
    ...
  spec:
    clusterRefs:
    - apiVersion: lib.projectsveltos.io/v1beta1
      kind: SveltosCluster
      name: my-service
      namespace: default
```

Fixes #368 