### PR TITLE
(bug): Prevent Hash Evaluation Failures from Template Instantiation

### DIFF
--- a/controllers/eventreport_collection.go
+++ b/controllers/eventreport_collection.go
@@ -503,6 +503,7 @@ func updateEventReport(ctx context.Context, c client.Client, cluster *corev1.Obj
 		if apierrors.IsNotFound(err) {
 			return eventReport, nil
 		}
+		return nil, err
 	}
 	if !currentEventSource.DeletionTimestamp.IsZero() {
 		return eventReport, nil

--- a/controllers/eventsource_controller.go
+++ b/controllers/eventsource_controller.go
@@ -70,7 +70,7 @@ func (r *EventSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, nil
 	}
 
-	return ctrl.Result{}, nil
+	return reconcile.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -572,6 +572,7 @@ func (r *EventTriggerReconciler) proceesAgentDeploymentStatus(ctx context.Contex
 			provisioning := libsveltosv1beta1.FeatureStatusProvisioning
 			return &provisioning, nil
 		}
+		return nil, err
 	}
 
 	return status.DeploymentStatus, err


### PR DESCRIPTION
Hash evaluation can involve templated EventSource and other resources. However, during hash evaluation, only cluster information is available, while template instantiation may depend on event-generating resources.

If template instantiation fails in this context, the hash evaluation should not error; instead, it should proceed.