### PR TITLE
(opt) Optmize EventReport collection

### DIFF
--- a/controllers/eventreport_collection.go
+++ b/controllers/eventreport_collection.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -43,6 +44,11 @@ import (
 const (
 	eventReportMalformedLabelError = "eventReport is malformed. Labels is empty"
 	eventReportMissingLabelError   = "eventReport is malformed. Label missing"
+
+	// clustersPerWorker controls how many clusters each worker goroutine handles.
+	clustersPerWorker = 50
+	// maxCollectionWorkers caps the number of concurrent goroutines collecting EventReports.
+	maxCollectionWorkers = 5
 )
 
 var (
@@ -158,6 +164,20 @@ func addEventTriggerMatchingCluster(et *v1beta1.EventTrigger,
 	return eventTriggerMap
 }
 
+// buildClustersWithEventTrigger returns the set of all clusters currently matched
+// by at least one EventTrigger, derived from EventTrigger.Status.MatchingClusterRefs.
+// This is used to skip clusters that have no EventTriggers and therefore no
+// EventReports to collect.
+func buildClustersWithEventTrigger(eventTriggers *v1beta1.EventTriggerList) map[corev1.ObjectReference]bool {
+	clusters := make(map[corev1.ObjectReference]bool)
+	for i := range eventTriggers.Items {
+		for j := range eventTriggers.Items[i].Status.MatchingClusterRefs {
+			clusters[eventTriggers.Items[i].Status.MatchingClusterRefs[j]] = true
+		}
+	}
+	return clusters
+}
+
 // buildClusterForEventTriggerMap builds a map:
 // key => eventTrigger name
 // values => slice of currently matching clusters
@@ -213,28 +233,34 @@ func collectEventReports(config *rest.Config, c client.Client, s *runtime.Scheme
 			continue
 		}
 
+		// Restrict collection to clusters actually matched by an EventTrigger.
+		// Clusters with no matching EventTrigger have no EventReports to collect,
+		// so we avoid all per-cluster API calls for them. clustersWithET is built
+		// from EventTrigger.Status.MatchingClusterRefs without shard awareness, so
+		// we intersect with the shard-local clusterList.
+		clustersWithET := buildClustersWithEventTrigger(eventTriggers)
+		var clustersToCollect []corev1.ObjectReference
+		for i := range clusterList {
+			if clustersWithET[clusterList[i]] {
+				clustersToCollect = append(clustersToCollect, clusterList[i])
+			}
+		}
+
 		allSuccessfull := true
 
-		for i := range clusterList {
-			cluster := &clusterList[i]
-
-			// Build a map of EventTrigger consuming an EventSource. This is built once per cluster
-			// as EventSourceName in EventTrigger.Spec can be expressed as a template and instantiated
-			// using cluster namespace, name and type.
-			eventSourceMap, err := buildEventTriggersForEventSourceMap(ctx, cluster, eventTriggers)
-			if err != nil {
-				time.Sleep(interval)
+		// In agentless mode all EventReports live in the management cluster.
+		// A single List call covers every cluster, avoiding N per-cluster API calls.
+		// skipCollecting is also only invoked for clusters that actually have EventReports
+		// needing attention.
+		if getAgentInMgmtCluster() {
+			if err := collectAndProcessAllEventReports(ctx, c, clustersToCollect, eventTriggers,
+				eventTriggerMap, version, firstCollection, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to collect EventReports")
 				allSuccessfull = false
-				continue
 			}
-
-			l := logger.WithValues("cluster", fmt.Sprintf("%s %s/%s", cluster.Kind, cluster.Namespace, cluster.Name))
-			err = collectAndProcessEventReportsFromCluster(ctx, c, cluster, eventSourceMap, eventTriggerMap,
-				version, firstCollection, l)
-			if err != nil {
-				l.V(logs.LogInfo).Error(err,
-					fmt.Sprintf("failed to collect EventReports from cluster: %s/%s",
-						cluster.Namespace, cluster.Name))
+		} else {
+			if err := processEventReportClusters(ctx, c, clustersToCollect, eventTriggers,
+				eventTriggerMap, version, firstCollection, logger); err != nil {
 				allSuccessfull = false
 			}
 		}
@@ -246,6 +272,238 @@ func collectEventReports(config *rest.Config, c client.Client, s *runtime.Scheme
 
 		time.Sleep(interval)
 	}
+}
+
+// collectEventReportFromCluster instantiates the per-cluster EventSource map and
+// delegates to collectAndProcessEventReportsFromCluster.
+func collectEventReportFromCluster(ctx context.Context, c client.Client,
+	cluster *corev1.ObjectReference,
+	eventTriggers *v1beta1.EventTriggerList,
+	eventTriggerMap map[string]libsveltosset.Set,
+	version string, firstCollection bool, logger logr.Logger) error {
+
+	eventSourceMap, err := buildEventTriggersForEventSourceMap(ctx, cluster, eventTriggers)
+	if err != nil {
+		return err
+	}
+
+	l := logger.WithValues("cluster", fmt.Sprintf("%s %s/%s", cluster.Kind, cluster.Namespace, cluster.Name))
+	return collectAndProcessEventReportsFromCluster(ctx, c, cluster, eventSourceMap, eventTriggerMap,
+		version, firstCollection, l)
+}
+
+// processEventReportClusters collects and processes EventReports for the given clusters.
+// It runs sequentially when there are fewer than clustersPerWorker clusters, and spawns
+// up to maxCollectionWorkers goroutines otherwise.
+func processEventReportClusters(ctx context.Context, c client.Client,
+	clusters []corev1.ObjectReference, eventTriggers *v1beta1.EventTriggerList,
+	eventTriggerMap map[string]libsveltosset.Set, version string, firstCollection bool,
+	logger logr.Logger) error {
+
+	logErr := func(cluster *corev1.ObjectReference, err error) {
+		logger.WithValues("cluster", fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name)).
+			V(logs.LogInfo).Info(fmt.Sprintf("failed to collect EventReports: %v", err))
+	}
+
+	numWorkers := len(clusters) / clustersPerWorker
+	if numWorkers > maxCollectionWorkers {
+		numWorkers = maxCollectionWorkers
+	}
+
+	if numWorkers == 0 {
+		// Sequential: fewer than clustersPerWorker clusters, goroutine overhead not justified.
+		var retErr error
+		for i := range clusters {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			cluster := &clusters[i]
+			if err := collectEventReportFromCluster(ctx, c, cluster, eventTriggers, eventTriggerMap,
+				version, firstCollection, logger); err != nil {
+				logErr(cluster, err)
+				retErr = err
+			}
+		}
+		return retErr
+	}
+
+	// Parallel: one worker per clustersPerWorker clusters, capped at maxCollectionWorkers.
+	work := make(chan corev1.ObjectReference, len(clusters))
+	for _, cluster := range clusters {
+		work <- cluster
+	}
+	close(work)
+
+	var (
+		mu     sync.Mutex
+		retErr error
+		wg     sync.WaitGroup
+	)
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for clusterRef := range work {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				ref := clusterRef
+				if err := collectEventReportFromCluster(ctx, c, &ref, eventTriggers, eventTriggerMap,
+					version, firstCollection, logger); err != nil {
+					logErr(&ref, err)
+					mu.Lock()
+					retErr = err
+					mu.Unlock()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return retErr
+	}
+}
+
+// collectAndProcessAllEventReports is used in agentless mode. It fetches all EventReports
+// from the management cluster in a single List call, groups the ones needing attention by
+// cluster, and processes only those clusters — avoiding N per-cluster List calls.
+func collectAndProcessAllEventReports(ctx context.Context, c client.Client,
+	clusterList []corev1.ObjectReference,
+	eventTriggers *v1beta1.EventTriggerList,
+	eventTriggerMap map[string]libsveltosset.Set,
+	version string, firstCollection bool, logger logr.Logger) error {
+
+	// Build a lookup of shard-local clusters keyed by namespace/name/clusterType to
+	// correctly distinguish a SveltosCluster from a CAPI Cluster with the same name.
+	type clusterKey struct{ ns, name, clusterType string }
+	shardClusters := make(map[clusterKey]corev1.ObjectReference, len(clusterList))
+	for i := range clusterList {
+		ref := clusterList[i]
+		ct := strings.ToLower(string(clusterproxy.GetClusterType(&ref)))
+		shardClusters[clusterKey{ref.Namespace, ref.Name, ct}] = ref
+	}
+
+	// Single List of all EventReports from the management cluster.
+	eventReportList := &libsveltosv1beta1.EventReportList{}
+	if err := getManagementClusterClient().List(ctx, eventReportList); err != nil {
+		return err
+	}
+
+	// Group EventReports needing attention by cluster. In steady state (not firstCollection)
+	// we skip already-processed EventReports to avoid unnecessary work.
+	type clusterData struct {
+		ref corev1.ObjectReference
+		ers []*libsveltosv1beta1.EventReport
+	}
+	byCluster := make(map[clusterKey]*clusterData)
+	for i := range eventReportList.Items {
+		er := &eventReportList.Items[i]
+		if er.Labels == nil {
+			continue
+		}
+		if !firstCollection && er.DeletionTimestamp.IsZero() && !shouldReprocess(er) {
+			continue
+		}
+		clusterName := er.Labels[libsveltosv1beta1.EventReportClusterNameLabel]
+		clusterType := er.Labels[libsveltosv1beta1.EventReportClusterTypeLabel]
+		clusterNs := er.Namespace
+		if clusterName == "" || clusterType == "" {
+			continue
+		}
+		key := clusterKey{clusterNs, clusterName, clusterType}
+		if _, ok := shardClusters[key]; !ok {
+			continue
+		}
+		cd, exists := byCluster[key]
+		if !exists {
+			ref := shardClusters[key]
+			cd = &clusterData{ref: ref}
+			byCluster[key] = cd
+		}
+		cd.ers = append(cd.ers, er)
+	}
+
+	var retErr error
+	for _, cd := range byCluster {
+		l := logger.WithValues("cluster", fmt.Sprintf("%s %s/%s", cd.ref.Kind, cd.ref.Namespace, cd.ref.Name))
+		if err := processEventReportsForClusterInAgentlessMode(ctx, c, &cd.ref, cd.ers, eventTriggers, eventTriggerMap,
+			version, firstCollection, l); err != nil {
+			retErr = err
+		}
+	}
+
+	return retErr
+}
+
+// processEventReportsForClusterInAgentlessMode handles all ready-to-process EventReports for a single
+// cluster in agentless mode. It checks readiness, version compatibility, and delegates
+// per-EventReport work to updateAllClusterProfiles / updateEventReportStatus.
+func processEventReportsForClusterInAgentlessMode(ctx context.Context, c client.Client,
+	ref *corev1.ObjectReference, ers []*libsveltosv1beta1.EventReport,
+	eventTriggers *v1beta1.EventTriggerList, eventTriggerMap map[string]libsveltosset.Set,
+	version string, firstCollection bool, logger logr.Logger) error {
+
+	skip, err := skipCollecting(ctx, c, ref, logger)
+	if err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, c, version, ref.Namespace, ref.Name,
+		clusterproxy.GetClusterType(ref), true, logger) {
+
+		logger.V(logs.LogDebug).Info("compatibility checks failed")
+		return errors.New("compatibility checks failed")
+	}
+
+	// EventSourceName in EventTrigger.Spec can be a template, so the map must be
+	// built per cluster using its namespace, name, and type.
+	eventSourceMap, err := buildEventTriggersForEventSourceMap(ctx, ref, eventTriggers)
+	if err != nil {
+		return err
+	}
+
+	var retErr error
+	mgmtClient := getManagementClusterClient()
+	for _, er := range ers {
+		reprocessing := firstCollection
+
+		if !er.DeletionTimestamp.IsZero() {
+			if err := deleteEventReport(ctx, c, ref, er, logger); err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to delete EventReport in management cluster")
+				retErr = err
+				continue
+			}
+			reprocessing = true
+		} else if shouldReprocess(er) {
+			// In agentless mode EventReports are generated directly in the management
+			// cluster, so no copy from the managed cluster is needed.
+			reprocessing = true
+		}
+
+		if !reprocessing {
+			continue
+		}
+
+		logger.V(logs.LogDebug).Info("processing EventReport")
+		if err := updateAllClusterProfiles(ctx, c, ref, er, eventSourceMap, eventTriggerMap, logger); err == nil {
+			updateEventReportStatus(ctx, mgmtClient, er, logger)
+		} else {
+			retErr = err
+		}
+	}
+
+	return retErr
 }
 
 func skipCollecting(ctx context.Context, c client.Client, cluster *corev1.ObjectReference,

--- a/controllers/eventreport_collection_test.go
+++ b/controllers/eventreport_collection_test.go
@@ -19,6 +19,7 @@ package controllers_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -47,10 +48,41 @@ var _ = Describe("EventSource Deployer", func() {
 	var logger logr.Logger
 	var version string
 
+	const cmVersionName = "sveltos-agent-version"
+
 	BeforeEach(func() {
 		version = randomString()
 		eventSource = getEventSourceInstance(randomString())
 		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+
+		By("Create the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controllers.ReportNamespace,
+				Name:      cmVersionName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Delete the ConfigMap with sveltos-agent version")
+		cm := &corev1.ConfigMap{}
+		Expect(testEnv.Get(context.TODO(),
+			types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+			cm)).To(Succeed())
+		Expect(testEnv.Delete(context.TODO(), cm)).To(Succeed())
+
+		Eventually(func() bool {
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: controllers.ReportNamespace, Name: cmVersionName},
+				cm)
+			return err != nil && apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
 	})
 
 	It("deleteEventReport ", func() {
@@ -147,7 +179,7 @@ var _ = Describe("EventSource Deployer", func() {
 	})
 
 	It("collectEventReports collects EventReports from clusters", func() {
-		cluster := prepareCluster(version)
+		cluster := prepareCluster()
 
 		// In managed cluster this is the namespace where EventReports
 		// are created
@@ -476,6 +508,127 @@ spec:
 		Expect(events[0]["specversion"]).To(Equal("1.0"))
 		Expect(events[0]["source"]).To(Equal("repo.requester.codesalot.com"))
 		Expect(events[0]["type"]).To(Equal("repo.error"))
+	})
+
+	It("buildClustersWithEventTrigger returns all clusters matched by any EventTrigger", func() {
+		cluster1 := corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		cluster2 := corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		}
+		cluster3 := corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		// cluster4 belongs to no EventTrigger — must be absent from the result.
+		cluster4 := corev1.ObjectReference{Namespace: randomString(), Name: randomString()}
+
+		// et1 matches cluster1+cluster2; et2 matches cluster2+cluster3.
+		eventTriggers := &v1beta1.EventTriggerList{
+			Items: []v1beta1.EventTrigger{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+					Spec:       v1beta1.EventTriggerSpec{EventSourceName: randomString()},
+					Status: v1beta1.EventTriggerStatus{
+						MatchingClusterRefs: []corev1.ObjectReference{cluster1, cluster2},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: randomString()},
+					Spec:       v1beta1.EventTriggerSpec{EventSourceName: randomString()},
+					Status: v1beta1.EventTriggerStatus{
+						MatchingClusterRefs: []corev1.ObjectReference{cluster2, cluster3},
+					},
+				},
+			},
+		}
+
+		result := controllers.BuildClustersWithEventTrigger(eventTriggers)
+
+		Expect(result[cluster1]).To(BeTrue())
+		Expect(result[cluster2]).To(BeTrue())
+		Expect(result[cluster3]).To(BeTrue())
+		Expect(result[cluster4]).To(BeFalse())
+	})
+
+	It("collectAndProcessAllEventReports distinguishes CAPI and Sveltos clusters with same namespace and name", func() {
+		// prepareCluster creates a ready CAPI cluster in testEnv so that
+		// skipCollecting passes when we process EventReports for it.
+		capiCluster := prepareCluster()
+
+		cmName := fmt.Sprintf("sa-%s-%s", strings.ToLower(string(libsveltosv1beta1.ClusterTypeCapi)), capiCluster.Name)
+		cmNamespace := capiCluster.Namespace
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cmNamespace,
+				Name:      cmName,
+			},
+			Data: map[string]string{
+				"version": version,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
+
+		// EventReport labeled as CAPI cluster — needs processing (Phase not set).
+		capiER := getEventReport(randomString(), capiCluster.Namespace, capiCluster.Name)
+		capiER.Labels[libsveltosv1beta1.EventReportClusterNameLabel] = capiCluster.Name
+		capiER.Labels[libsveltosv1beta1.EventReportClusterTypeLabel] = strings.ToLower(string(libsveltosv1beta1.ClusterTypeCapi))
+		Expect(testEnv.Create(context.TODO(), capiER)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, capiER)).To(Succeed())
+
+		// EventReport labeled as Sveltos cluster — same namespace/name as the CAPI cluster.
+		// Must NOT be processed since its cluster type is not in clusterList.
+		sveltosER := getEventReport(randomString(), capiCluster.Namespace, capiCluster.Name)
+		sveltosER.Labels[libsveltosv1beta1.EventReportClusterNameLabel] = capiCluster.Name
+		sveltosER.Labels[libsveltosv1beta1.EventReportClusterTypeLabel] = strings.ToLower(string(libsveltosv1beta1.ClusterTypeSveltos))
+		Expect(testEnv.Create(context.TODO(), sveltosER)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, sveltosER)).To(Succeed())
+
+		// Only the CAPI cluster is in clusterList.
+		capiClusterRef := corev1.ObjectReference{
+			Namespace:  capiCluster.Namespace,
+			Name:       capiCluster.Name,
+			Kind:       "Cluster",
+			APIVersion: clusterv1.GroupVersion.String(),
+		}
+
+		eventTriggers := &v1beta1.EventTriggerList{}
+		eventTriggerMap := map[string]libsveltosset.Set{}
+
+		Expect(controllers.CollectAndProcessAllEventReports(context.TODO(), testEnv.Client,
+			[]corev1.ObjectReference{capiClusterRef}, eventTriggers, eventTriggerMap,
+			version, false, logger)).To(Succeed())
+
+		// The CAPI EventReport must be marked as processed.
+		Eventually(func() bool {
+			current := &libsveltosv1beta1.EventReport{}
+			if err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: capiER.Namespace, Name: capiER.Name}, current); err != nil {
+				return false
+			}
+			return current.Status.Phase != nil && *current.Status.Phase == libsveltosv1beta1.ReportProcessed
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		// The Sveltos EventReport must not have been processed — its cluster type was
+		// not in clusterList so collectAndProcessAllEventReports must have ignored it.
+		Consistently(func() bool {
+			current := &libsveltosv1beta1.EventReport{}
+			if err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: sveltosER.Namespace, Name: sveltosER.Name}, current); err != nil {
+				return false
+			}
+			return current.Status.Phase == nil || *current.Status.Phase != libsveltosv1beta1.ReportProcessed
+		}, timeout, pollingInterval).Should(BeTrue())
 	})
 
 	It("instantiateCloudEventAction ", func() {

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -25,6 +25,7 @@ var (
 	RemoveEventReports                       = removeEventReports
 	RemoveEventReportsFromCluster            = removeEventReportsFromCluster
 	CollectAndProcessEventReportsFromCluster = collectAndProcessEventReportsFromCluster
+	CollectAndProcessAllEventReports         = collectAndProcessAllEventReports
 	DeleteEventReport                        = deleteEventReport
 	ProcessEventTriggerForCluster            = processEventTriggerForCluster
 )
@@ -78,6 +79,7 @@ var (
 
 	BuildEventTriggersForEventSourceMap = buildEventTriggersForEventSourceMap
 	BuildEventTriggersForClusterMap     = buildEventTriggersForClusterMap
+	BuildClustersWithEventTrigger       = buildClustersWithEventTrigger
 	ShouldIgnore                        = shouldIgnore
 	ShouldReprocess                     = shouldReprocess
 	IsEventTriggerMatchingTheCluster    = isEventTriggerMatchingTheCluster

--- a/controllers/suite_utils_test.go
+++ b/controllers/suite_utils_test.go
@@ -40,7 +40,6 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/event-manager/api/v1beta1"
-	"github.com/projectsveltos/event-manager/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 )
 
@@ -169,7 +168,7 @@ func getEventReport(eventSourceName, clusterNamespace, clusterName string) *libs
 	}
 }
 
-func prepareCluster(version string) *clusterv1.Cluster {
+func prepareCluster() *clusterv1.Cluster {
 	namespace := randomString()
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -228,19 +227,6 @@ func prepareCluster(version string) *clusterv1.Cluster {
 	}
 	Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv.Client, secret)).To(Succeed())
-
-	By("Create the ConfigMap with sveltos-agent version")
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: controllers.ReportNamespace,
-			Name:      "sveltos-agent-version",
-		},
-		Data: map[string]string{
-			"version": version,
-		},
-	}
-	Expect(testEnv.Create(context.TODO(), cm)).To(Succeed())
-	Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
 
 	Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
 


### PR DESCRIPTION
When in agentless mode, all EventReport instances are in the management cluster. Instead of doing one query per cluster to get EventReports for a given cluster, query once all EventReports instances. Then process only the instance for managed clusters with correct cluster shard.

Collect EventReports only from clusters that match at least one EventTrigger. This avoids collecting from clusters with no EventReports.

When more than 50 clusters are present with drift detection, use workers to parallelize the work (up to 5 workers).