### PR TITLE
(feat) Guard against transient empty EventReports before deleting ClusterProfiles

### DIFF
--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -1359,12 +1360,11 @@ func updateClusterProfiles(ctx context.Context, c client.Client, clusterNamespac
 	logger logr.Logger) error {
 
 	var err error
-	// If no resource is currently matching, clear all
-	if !er.DeletionTimestamp.IsZero() || !hasMatchingResources(er) {
-		logger.V(logs.LogDebug).Info("EventReport is deleted or has no matching resources")
-		// ClusterProfiles created because of CloudEvents are removed when CloudEventAction is set to Delete.
-		// Fetch all ClusterProfiles created because of CloudEvents by this eventTrigger and append to list
-		// of ClusterProfiles that are not stale
+
+	// EventReport explicitly deleted: remove immediately, no safeguard needed.
+	if !er.DeletionTimestamp.IsZero() {
+		logger.V(logs.LogDebug).Info("EventReport is being deleted")
+		resetZeroMatchCount(er, eventTrigger.Name)
 		clusterProfiles := []*configv1beta1.ClusterProfile{}
 		clusterProfiles, err = appendCloudEventClusterProfiles(ctx, c, clusterNamespace, clusterName, eventTrigger.Name,
 			clusterType, er, clusterProfiles)
@@ -1374,6 +1374,33 @@ func updateClusterProfiles(ctx context.Context, c client.Client, clusterNamespac
 		return removeInstantiatedResources(ctx, c, clusterNamespace, clusterName, clusterType,
 			eventTrigger, er, clusterProfiles, nil, logger)
 	}
+
+	// No matching resources: require zeroMatchThreshold consecutive observations before removing
+	// ClusterProfiles, to guard against transient empty EventReports (e.g. from a sveltos-agent
+	// internal restart before its informers have re-synced).
+	if !hasMatchingResources(er) {
+		count := incrementZeroMatchCount(er, eventTrigger.Name)
+		if count < zeroMatchThreshold {
+			logger.V(logs.LogInfo).Info("EventReport has no matching resources, waiting for confirmation",
+				"count", count, "threshold", zeroMatchThreshold)
+			return fmt.Errorf("EventReport %s/%s shows no matches (%d/%d), requeuing",
+				er.Namespace, er.Name, count, zeroMatchThreshold)
+		}
+		logger.V(logs.LogDebug).Info("EventReport has no matching resources confirmed, removing ClusterProfiles",
+			"count", count)
+		resetZeroMatchCount(er, eventTrigger.Name)
+		clusterProfiles := []*configv1beta1.ClusterProfile{}
+		clusterProfiles, err = appendCloudEventClusterProfiles(ctx, c, clusterNamespace, clusterName, eventTrigger.Name,
+			clusterType, er, clusterProfiles)
+		if err != nil {
+			return err
+		}
+		return removeInstantiatedResources(ctx, c, clusterNamespace, clusterName, clusterType,
+			eventTrigger, er, clusterProfiles, nil, logger)
+	}
+
+	// Has matching resources: reset the zero-match counter.
+	resetZeroMatchCount(er, eventTrigger.Name)
 
 	var clusterProfiles []*configv1beta1.ClusterProfile
 	var fromGenerators []libsveltosv1beta1.PolicyRef
@@ -3308,6 +3335,50 @@ func getValuesFrom(ctx context.Context, c client.Client, valuesFrom []configv1be
 		result = append(result, resource)
 	}
 	return result
+}
+
+// zeroMatchCounts tracks the number of consecutive collection cycles in which a given
+// (EventReport, EventTrigger) pair reported zero matching resources.
+// Key format: "<erNamespace>/<erName>/<eventTriggerName>".
+// Not persisted across event-manager restarts; that is intentional.
+var (
+	zeroMatchCounts sync.Map
+)
+
+const (
+	zeroMatchThreshold = 3
+)
+
+func zeroMatchKey(er *libsveltosv1beta1.EventReport, eventTriggerName string) string {
+	return er.Namespace + "/" + er.Name + "/" + eventTriggerName
+}
+
+// incrementZeroMatchCount bumps the counter and returns the new value.
+func incrementZeroMatchCount(er *libsveltosv1beta1.EventReport, eventTriggerName string) int {
+	key := zeroMatchKey(er, eventTriggerName)
+	for {
+		existing, loaded := zeroMatchCounts.Load(key)
+		var cur int
+		if loaded {
+			cur = existing.(int)
+		}
+		next := cur + 1
+		if !loaded {
+			if _, loaded2 := zeroMatchCounts.LoadOrStore(key, next); !loaded2 {
+				return next
+			}
+			// Another goroutine stored first; retry.
+			continue
+		}
+		if zeroMatchCounts.CompareAndSwap(key, cur, next) {
+			return next
+		}
+	}
+}
+
+// resetZeroMatchCount removes the counter entry for this (EventReport, EventTrigger) pair.
+func resetZeroMatchCount(er *libsveltosv1beta1.EventReport, eventTriggerName string) {
+	zeroMatchCounts.Delete(zeroMatchKey(er, eventTriggerName))
 }
 
 func hasMatchingResources(er *libsveltosv1beta1.EventReport) bool {

--- a/controllers/eventtrigger_deployer_test.go
+++ b/controllers/eventtrigger_deployer_test.go
@@ -2449,6 +2449,77 @@ data:
 		Expect(len(secretList.Items)).To(Equal(1))
 		Expect(secretList.Items[0].Name).To(Equal(currentSecret.Name))
 	})
+
+	It("incrementZeroMatchCount increments per (EventReport, EventTrigger) key", func() {
+		controllers.ResetZeroMatchCounters()
+
+		er := &libsveltosv1beta1.EventReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+			},
+		}
+		etName := randomString()
+
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(1))
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(2))
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(3))
+
+		// A different EventTrigger name keeps its own counter.
+		otherEtName := randomString()
+		Expect(controllers.IncrementZeroMatchCount(er, otherEtName)).To(Equal(1))
+
+		// A different EventReport keeps its own counter.
+		er2 := &libsveltosv1beta1.EventReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+			},
+		}
+		Expect(controllers.IncrementZeroMatchCount(er2, etName)).To(Equal(1))
+	})
+
+	It("resetZeroMatchCount clears the counter", func() {
+		controllers.ResetZeroMatchCounters()
+
+		er := &libsveltosv1beta1.EventReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+			},
+		}
+		etName := randomString()
+
+		controllers.IncrementZeroMatchCount(er, etName)
+		controllers.IncrementZeroMatchCount(er, etName)
+		controllers.ResetZeroMatchCount(er, etName)
+
+		// After reset the counter starts from 1 again.
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(1))
+	})
+
+	It("zero-match counter reaches threshold and resets", func() {
+		controllers.ResetZeroMatchCounters()
+
+		er := &libsveltosv1beta1.EventReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: randomString(),
+				Name:      randomString(),
+			},
+		}
+		etName := randomString()
+
+		threshold := controllers.ZeroMatchThreshold
+		for i := 1; i < threshold; i++ {
+			Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(i))
+		}
+		// Reaching the threshold.
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(threshold))
+
+		// After the caller resets on threshold, next increment starts at 1.
+		controllers.ResetZeroMatchCount(er, etName)
+		Expect(controllers.IncrementZeroMatchCount(er, etName)).To(Equal(1))
+	})
 })
 
 func validateLabels(labels map[string]string, clusterRef *corev1.ObjectReference,

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -114,3 +114,19 @@ func SetSchema(s *runtime.Scheme) {
 func SetConfig(config *rest.Config) {
 	mgmtClusterConfig = config
 }
+
+var (
+	HasMatchingResources    = hasMatchingResources
+	IncrementZeroMatchCount = incrementZeroMatchCount
+	ResetZeroMatchCount     = resetZeroMatchCount
+	ZeroMatchThreshold      = zeroMatchThreshold
+)
+
+// ResetZeroMatchCounters clears all entries in the package-level counter map.
+// For use in tests only.
+func ResetZeroMatchCounters() {
+	zeroMatchCounts.Range(func(k, _ any) bool {
+		zeroMatchCounts.Delete(k)
+		return true
+	})
+}


### PR DESCRIPTION
A transient empty EventReport is a dangerous signal to act on immediately. Any condition that causes the agent to report zero matching resource, whether a brief informer inconsistency, a network hiccup, or an edge case not yet identified, would result in ClusterProfiles being deleted and then recreated, causing unnecessary churn in the managed cluster.

event-manager now requires three consecutive collection cycles with zero matching resources before removing ClusterProfiles.
On each of the first two observations it returns an error so the EventReport stays unprocessed and is picked up again on the next poll. On the third consecutive observation it proceeds with the removal.

The safeguard does not apply when the EventReport itself is being deleted, since in that case removal is intentional and should happen immediately. When matching resources are present the counter resets, so the threshold is always three consecutive observations rather than four cumulative ones.