### PR TITLE
fix: HelmChart/KustomizationRef template values containing quoted string function arguments

### DIFF
--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -1783,18 +1783,34 @@ func setClusterSelector(clusterProfileSpec *configv1beta1.Spec, clusterNamespace
 		useSameCluster = false
 		templateName := getTemplateName(clusterNamespace, clusterName, eventTrigger.Name)
 
-		raw, err := json.Marshal(*eventTrigger.Spec.DestinationCluster)
+		// Instantiated field-by-field (not by JSON-marshaling the whole ObjectReference and
+		// templating that as one blob): a quoted string literal used as a function argument
+		// inside a template action would otherwise be corrupted by JSON's quote escaping
+		// before the template engine ever sees it.
+		destinationCluster := *eventTrigger.Spec.DestinationCluster.DeepCopy()
+
+		var err error
+		destinationCluster.Namespace, err = instantiateStringField(templateName, "destinationCluster.namespace",
+			destinationCluster.Namespace, data, false, logger)
 		if err != nil {
 			return err
 		}
 
-		instantiated, err := instantiateSection(templateName, raw, data, false, logger)
+		destinationCluster.Name, err = instantiateStringField(templateName, "destinationCluster.name",
+			destinationCluster.Name, data, false, logger)
 		if err != nil {
 			return err
 		}
 
-		var destinationCluster corev1.ObjectReference
-		if err := json.Unmarshal(instantiated, &destinationCluster); err != nil {
+		destinationCluster.Kind, err = instantiateStringField(templateName, "destinationCluster.kind",
+			destinationCluster.Kind, data, false, logger)
+		if err != nil {
+			return err
+		}
+
+		destinationCluster.APIVersion, err = instantiateStringField(templateName, "destinationCluster.apiVersion",
+			destinationCluster.APIVersion, data, false, logger)
+		if err != nil {
 			return err
 		}
 
@@ -1901,36 +1917,86 @@ func instantiateSection(templateName string, toBeInstantiated []byte, data any,
 	return buffer.Bytes(), nil
 }
 
+// instantiateStringField instantiates a single string field as its own Go template and
+// returns the result. Fields are instantiated one at a time (rather than JSON-marshaling a
+// whole struct/slice and templating that as one blob) so a quoted string literal used as a
+// function argument inside a template action (e.g. {{ replace "-control-plane" "" .Name }})
+// is never corrupted by JSON's quote/newline escaping before the template engine sees it.
+func instantiateStringField(templateName, fieldName, value string, data any, useTxtFuncMap bool,
+	logger logr.Logger) (string, error) {
+
+	instantiated, err := instantiateSection(templateName, []byte(value), data, useTxtFuncMap, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, fmt.Sprintf("failed to instantiate %s", fieldName))
+		return "", err
+	}
+	return string(instantiated), nil
+}
+
 func instantiateHelmCharts(ctx context.Context, c client.Client, e *v1beta1.EventTrigger,
 	clusterNamespace, templateName string, helmCharts []configv1beta1.HelmChart, data any,
 	labels map[string]string, logger logr.Logger) ([]configv1beta1.HelmChart, error) {
 
-	helmChartJson, err := json.Marshal(helmCharts)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to marshel helmCharts")
-		return nil, err
-	}
+	useTxtFuncMap := funcmap.HasTextTemplateAnnotation(e.Annotations)
 
-	instantiatedData, err := instantiateSection(templateName, helmChartJson, data,
-		funcmap.HasTextTemplateAnnotation(e.Annotations), logger)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to execute template")
-		return nil, err
-	}
+	instantiatedHelmCharts := make([]configv1beta1.HelmChart, len(helmCharts))
+	for i := range helmCharts {
+		// DeepCopy, not a plain struct copy: ValuesFrom (mutated in place by instantiateValuesFrom
+		// below) and other slice/map fields would otherwise still share their backing array/map
+		// with the original helmCharts[i], corrupting it for any other caller reusing the same
+		// EventTrigger spec (e.g. one instantiation per matching resource in oneForEvent mode).
+		instantiatedHelmChart := *helmCharts[i].DeepCopy()
 
-	instantiatedHelmCharts := make([]configv1beta1.HelmChart, 0)
-	err = json.Unmarshal(instantiatedData, &instantiatedHelmCharts)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to unmarshal helmCharts")
-		return nil, err
-	}
+		var err error
+		instantiatedHelmChart.RepositoryURL, err = instantiateStringField(templateName, "repositoryURL",
+			instantiatedHelmChart.RepositoryURL, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
 
-	for i := range instantiatedHelmCharts {
-		err = instantiateValuesFrom(ctx, c, e, instantiatedHelmCharts[i].ValuesFrom,
+		instantiatedHelmChart.RepositoryName, err = instantiateStringField(templateName, "repositoryName",
+			instantiatedHelmChart.RepositoryName, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedHelmChart.ChartName, err = instantiateStringField(templateName, "chartName",
+			instantiatedHelmChart.ChartName, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedHelmChart.ChartVersion, err = instantiateStringField(templateName, "chartVersion",
+			instantiatedHelmChart.ChartVersion, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedHelmChart.ReleaseName, err = instantiateStringField(templateName, "releaseName",
+			instantiatedHelmChart.ReleaseName, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedHelmChart.ReleaseNamespace, err = instantiateStringField(templateName, "releaseNamespace",
+			instantiatedHelmChart.ReleaseNamespace, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedHelmChart.Values, err = instantiateStringField(templateName, "values",
+			instantiatedHelmChart.Values, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		err = instantiateValuesFrom(ctx, c, e, instantiatedHelmChart.ValuesFrom,
 			clusterNamespace, templateName, data, labels, logger)
 		if err != nil {
 			return nil, err
 		}
+
+		instantiatedHelmCharts[i] = instantiatedHelmChart
 	}
 
 	return instantiatedHelmCharts, nil
@@ -1940,32 +2006,64 @@ func instantiateKustomizationRefs(ctx context.Context, c client.Client, e *v1bet
 	clusterNamespace, templateName string, kustomizationRefs []configv1beta1.KustomizationRef,
 	data any, labels map[string]string, logger logr.Logger) ([]configv1beta1.KustomizationRef, error) {
 
-	kustomizationRefsJson, err := json.Marshal(kustomizationRefs)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to marshel kustomizationRefs")
-		return nil, err
-	}
+	useTxtFuncMap := funcmap.HasTextTemplateAnnotation(e.Annotations)
 
-	instantiatedData, err := instantiateSection(templateName, kustomizationRefsJson, data,
-		funcmap.HasTextTemplateAnnotation(e.Annotations), logger)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to execute template")
-		return nil, err
-	}
+	instantiatedKustomizationRefs := make([]configv1beta1.KustomizationRef, len(kustomizationRefs))
+	for i := range kustomizationRefs {
+		// DeepCopy, not a plain struct copy: ValuesFrom (mutated in place by instantiateValuesFrom
+		// below), Components, and Values would otherwise still share their backing array/map with
+		// the original kustomizationRefs[i], corrupting it for any other caller reusing the same
+		// EventTrigger spec (e.g. one instantiation per matching resource in oneForEvent mode).
+		instantiatedRef := *kustomizationRefs[i].DeepCopy()
 
-	instantiatedKustomizationRefs := make([]configv1beta1.KustomizationRef, 0)
-	err = json.Unmarshal(instantiatedData, &instantiatedKustomizationRefs)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to unmarshal kustomizationRefs")
-		return nil, err
-	}
+		var err error
+		instantiatedRef.Namespace, err = instantiateStringField(templateName, "namespace",
+			instantiatedRef.Namespace, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
 
-	for i := range instantiatedKustomizationRefs {
-		err = instantiateValuesFrom(ctx, c, e, instantiatedKustomizationRefs[i].ValuesFrom,
+		instantiatedRef.Name, err = instantiateStringField(templateName, "name",
+			instantiatedRef.Name, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedRef.Path, err = instantiateStringField(templateName, "path",
+			instantiatedRef.Path, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		instantiatedRef.TargetNamespace, err = instantiateStringField(templateName, "targetNamespace",
+			instantiatedRef.TargetNamespace, data, useTxtFuncMap, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		for j := range instantiatedRef.Components {
+			instantiatedRef.Components[j], err = instantiateStringField(templateName, "components",
+				instantiatedRef.Components[j], data, useTxtFuncMap, logger)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		for k, v := range instantiatedRef.Values {
+			instantiatedRef.Values[k], err = instantiateStringField(templateName, "values",
+				v, data, useTxtFuncMap, logger)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = instantiateValuesFrom(ctx, c, e, instantiatedRef.ValuesFrom,
 			clusterNamespace, templateName, data, labels, logger)
 		if err != nil {
 			return nil, err
 		}
+
+		instantiatedKustomizationRefs[i] = instantiatedRef
 	}
 
 	return instantiatedKustomizationRefs, nil

--- a/controllers/eventtrigger_deployer_test.go
+++ b/controllers/eventtrigger_deployer_test.go
@@ -2538,3 +2538,137 @@ func validateLabels(labels map[string]string, clusterRef *corev1.ObjectReference
 		Expect(v).To(Equal(expectedLabels[k]))
 	}
 }
+
+const (
+	testEksChartsRepoURL    = "https://aws.github.io/eks-charts"
+	testAWSLBControllerName = "aws-load-balancer-controller"
+	testKubeSystemNamespace = "kube-system"
+	testResourceDataKey     = "Resource"
+	testMetadataDataKey     = "metadata"
+	testControlPlaneCluster = "my-cluster-control-plane"
+	testNameDataKey         = "name"
+	testFluxSystemName      = "flux-system"
+)
+
+var _ = Describe("InstantiateHelmCharts and InstantiateKustomizationRefs", func() {
+	// Regression test for a bug where the whole helmCharts/kustomizationRefs slice was
+	// JSON-marshaled and templated as one blob: JSON-escaping a quoted string literal used as
+	// a function argument inside a template action (e.g. `replace "-control-plane" ""`) turned
+	// it into `replace \"-control-plane\" \"\"`, which Go's template parser rejects with
+	// `unexpected "\\" in operand`. Fields are now instantiated one at a time instead.
+
+	var logger logr.Logger
+	var e *v1beta1.EventTrigger
+
+	BeforeEach(func() {
+		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		e = &v1beta1.EventTrigger{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+		}
+	})
+
+	It("InstantiateHelmCharts succeeds with a quoted string literal function argument", func() {
+		helmCharts := []configv1beta1.HelmChart{
+			{
+				RepositoryURL:    testEksChartsRepoURL,
+				RepositoryName:   "eks",
+				ChartName:        testAWSLBControllerName,
+				ChartVersion:     "3.4.0",
+				ReleaseName:      testAWSLBControllerName,
+				ReleaseNamespace: testKubeSystemNamespace,
+				HelmChartAction:  configv1beta1.HelmChartActionInstall,
+				Values: `clusterName: {{ .Resource.metadata.name | replace "-control-plane" "" }}
+`,
+			},
+		}
+
+		data := map[string]interface{}{
+			testResourceDataKey: map[string]interface{}{
+				testMetadataDataKey: map[string]interface{}{
+					testNameDataKey: testControlPlaneCluster,
+				},
+			},
+		}
+
+		instantiated, err := controllers.InstantiateHelmCharts(context.TODO(), nil, e,
+			randomString(), randomString(), helmCharts, data, nil, logger)
+		Expect(err).To(BeNil())
+		Expect(instantiated).To(HaveLen(1))
+		Expect(instantiated[0].Values).To(Equal("clusterName: my-cluster\n"))
+
+		// the original slice passed in must be untouched (no aliasing/mutation)
+		Expect(helmCharts[0].Values).To(ContainSubstring(`replace "-control-plane" ""`))
+	})
+
+	It("InstantiateHelmCharts does not mutate or alias the input across repeated calls", func() {
+		helmCharts := []configv1beta1.HelmChart{
+			{
+				RepositoryURL:    testEksChartsRepoURL,
+				ReleaseName:      "{{ .Resource.metadata.name }}",
+				ReleaseNamespace: testKubeSystemNamespace,
+				Values:           "clusterName: {{ .Resource.metadata.name }}\n",
+			},
+		}
+
+		dataOne := map[string]interface{}{
+			testResourceDataKey: map[string]interface{}{testMetadataDataKey: map[string]interface{}{testNameDataKey: "cluster-one"}},
+		}
+		dataTwo := map[string]interface{}{
+			testResourceDataKey: map[string]interface{}{testMetadataDataKey: map[string]interface{}{testNameDataKey: "cluster-two"}},
+		}
+
+		instantiatedOne, err := controllers.InstantiateHelmCharts(context.TODO(), nil, e,
+			randomString(), randomString(), helmCharts, dataOne, nil, logger)
+		Expect(err).To(BeNil())
+		Expect(instantiatedOne[0].ReleaseName).To(Equal("cluster-one"))
+		Expect(instantiatedOne[0].Values).To(Equal("clusterName: cluster-one\n"))
+
+		// original input must still hold the raw, un-instantiated template text
+		Expect(helmCharts[0].ReleaseName).To(Equal("{{ .Resource.metadata.name }}"))
+		Expect(helmCharts[0].Values).To(Equal("clusterName: {{ .Resource.metadata.name }}\n"))
+
+		instantiatedTwo, err := controllers.InstantiateHelmCharts(context.TODO(), nil, e,
+			randomString(), randomString(), helmCharts, dataTwo, nil, logger)
+		Expect(err).To(BeNil())
+		Expect(instantiatedTwo[0].ReleaseName).To(Equal("cluster-two"))
+		Expect(instantiatedTwo[0].Values).To(Equal("clusterName: cluster-two\n"))
+
+		// first result must not have been retroactively changed by the second call
+		Expect(instantiatedOne[0].ReleaseName).To(Equal("cluster-one"))
+	})
+
+	It("InstantiateKustomizationRefs succeeds with a quoted string literal function argument", func() {
+		kustomizationRefs := []configv1beta1.KustomizationRef{
+			{
+				Namespace: testFluxSystemName,
+				Name:      testFluxSystemName,
+				Kind:      "GitRepository",
+				Path:      `./kustomize-resources/{{ .Resource.metadata.name | replace "-control-plane" "" }}/`,
+				Values: map[string]string{
+					"region": `{{ .Resource.metadata.labels.awsAccount | replace "-" "" }}`,
+				},
+			},
+		}
+
+		data := map[string]interface{}{
+			testResourceDataKey: map[string]interface{}{
+				testMetadataDataKey: map[string]interface{}{
+					testNameDataKey: testControlPlaneCluster,
+					"labels":        map[string]interface{}{"awsAccount": "111-222"},
+				},
+			},
+		}
+
+		instantiated, err := controllers.InstantiateKustomizationRefs(context.TODO(), nil, e,
+			randomString(), randomString(), kustomizationRefs, data, nil, logger)
+		Expect(err).To(BeNil())
+		Expect(instantiated).To(HaveLen(1))
+		Expect(instantiated[0].Path).To(Equal("./kustomize-resources/my-cluster/"))
+		Expect(instantiated[0].Values["region"]).To(Equal("111222"))
+
+		// the original slice passed in must be untouched (no aliasing/mutation)
+		Expect(kustomizationRefs[0].Path).To(ContainSubstring(`replace "-control-plane" ""`))
+	})
+})

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -77,6 +77,10 @@ var (
 	RemoveSecrets                   = removeSecrets
 	UnstructuredToTyped             = unstructuredToTyped
 
+	InstantiateHelmCharts        = instantiateHelmCharts
+	InstantiateKustomizationRefs = instantiateKustomizationRefs
+	InstantiateStringField       = instantiateStringField
+
 	BuildEventTriggersForEventSourceMap = buildEventTriggersForEventSourceMap
 	BuildEventTriggersForClusterMap     = buildEventTriggersForClusterMap
 	BuildClustersWithEventTrigger       = buildClustersWithEventTrigger

--- a/test/fv/instantiate_helmchart_replace_test.go
+++ b/test/fv/instantiate_helmchart_replace_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/event-manager/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+// Regression test for a bug where helmCharts fields were JSON-marshaled as a whole slice and
+// templated as one blob: JSON-escaping a quoted string literal used as a function argument
+// inside a template action (e.g. `replace "-svc" ""`) corrupted the quotes, and Go's template
+// parser rejected the result with `unexpected "\\" in operand`. Fields are now instantiated one
+// at a time, so a quoted string literal argument survives untouched.
+var _ = Describe("Instantiate HelmChart fields containing a quoted string literal function argument", func() {
+	const (
+		namePrefix = "events-helm-replace"
+	)
+
+	It("Verifies a helmChart field using replace with quoted arguments instantiates correctly",
+		Label("FV", "PULLMODE"), func() {
+			serviceNamespace := randomString()
+
+			eventSource := libsveltosv1beta1.EventSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomString(),
+				},
+				Spec: libsveltosv1beta1.EventSourceSpec{
+					ResourceSelectors: []libsveltosv1beta1.ResourceSelector{
+						{
+							Group:     "",
+							Version:   coreV1Version,
+							Kind:      serviceKind,
+							Namespace: serviceNamespace,
+						},
+					},
+					CollectResources: true,
+				},
+			}
+			Byf("Create a EventSource %s matching in namespace: %s",
+				eventSource.Name, serviceNamespace)
+			Expect(k8sClient.Create(context.TODO(), &eventSource)).To(Succeed())
+
+			eventTrigger := getEventTrigger(namePrefix, eventSource.Name,
+				map[string]string{key: value}, []configv1beta1.PolicyRef{})
+			eventTrigger.Spec.OneForEvent = true
+			eventTrigger.Spec.HelmCharts = []configv1beta1.HelmChart{
+				{
+					RepositoryURL:  metallbRepositoryURL,
+					RepositoryName: metallbRepositoryName,
+					ChartName:      metallbChartName,
+					ChartVersion:   metallbChartVersion,
+					// This is the bug trigger: a quoted string literal ("-svc", "") passed as a
+					// function argument inside a template action.
+					ReleaseName:      `{{ .Resource.metadata.name | replace "-svc" "" }}`,
+					ReleaseNamespace: resourceNamespaceTemplate,
+					HelmChartAction:  configv1beta1.HelmChartActionInstall,
+				},
+			}
+			Byf("Create a EventTrigger %s referencing EventSource %s",
+				eventTrigger.Name, eventSource.Name)
+			Expect(k8sClient.Create(context.TODO(), eventTrigger)).To(Succeed())
+
+			Byf("Getting client to access the workload cluster")
+			workloadClient, err := getKindWorkloadClusterKubeconfig()
+			Expect(err).To(BeNil())
+			Expect(workloadClient).ToNot(BeNil())
+
+			Byf("Create namespace %s in the managed cluster", serviceNamespace)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: serviceNamespace,
+				},
+			}
+			Expect(workloadClient.Create(context.TODO(), ns)).To(Succeed())
+
+			serviceName := randomString() + "-svc"
+			Byf("Creating a Service %s in namespace %s in the managed cluster", serviceName, serviceNamespace)
+			var port int32 = 8080
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: serviceNamespace, // EventSource filters service in this namespace
+					Name:      serviceName,
+					Labels: map[string]string{
+						randomString(): randomString(),
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						randomString(): randomString(),
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name: randomString(),
+							Port: port,
+						},
+					},
+				},
+			}
+			Expect(workloadClient.Create(context.TODO(), service)).To(Succeed())
+
+			By("Verifying ClusterProfile has been created (template instantiation succeeded)")
+			Eventually(func() bool {
+				listOptions := []client.ListOption{
+					client.MatchingLabels(getInstantiatedObjectLabels(eventTrigger.Name)),
+				}
+				clusterProfileList := &configv1beta1.ClusterProfileList{}
+				err = k8sClient.List(context.TODO(), clusterProfileList, listOptions...)
+				if err != nil {
+					return false
+				}
+				return len(clusterProfileList.Items) == 1
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			listOptions := []client.ListOption{
+				client.MatchingLabels(getInstantiatedObjectLabels(eventTrigger.Name)),
+			}
+			clusterProfileList := &configv1beta1.ClusterProfileList{}
+			Expect(k8sClient.List(context.TODO(), clusterProfileList, listOptions...)).To(Succeed())
+			clusterProfile := &clusterProfileList.Items[0]
+
+			Expect(len(clusterProfile.Spec.HelmCharts)).To(Equal(1))
+
+			Byf("Verifying ReleaseName was instantiated correctly (replace with quoted arguments applied)")
+			expectedReleaseName := serviceName[:len(serviceName)-len("-svc")]
+			Expect(clusterProfile.Spec.HelmCharts[0].ReleaseName).To(Equal(expectedReleaseName))
+			Expect(clusterProfile.Spec.HelmCharts[0].ReleaseNamespace).To(Equal(serviceNamespace))
+
+			verifyClusterSummary(clusterProfile, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+
+			Byf("Deleting EventTrigger %s", eventTrigger.Name)
+			currentEventTrigger := &v1beta1.EventTrigger{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: eventTrigger.Name},
+				currentEventTrigger)).To(Succeed())
+			Expect(k8sClient.Delete(context.TODO(), currentEventTrigger)).To(Succeed())
+
+			verifyClusterProfilesAreGone(eventTrigger.Name)
+
+			Byf("Verifying EventTrigger %s is removed from the management cluster", eventTrigger.Name)
+			Eventually(func() bool {
+				err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: eventTrigger.Name},
+					currentEventTrigger)
+				return err != nil && apierrors.IsNotFound(err)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Byf("Deleting EventSource %s in the managed cluster", eventSource.Name)
+			currentEventSource := &libsveltosv1beta1.EventSource{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: eventSource.Name},
+				currentEventSource)).To(Succeed())
+			Expect(k8sClient.Delete(context.TODO(), currentEventSource)).To(Succeed())
+		})
+})

--- a/test/fv/instantiate_helmchart_test.go
+++ b/test/fv/instantiate_helmchart_test.go
@@ -89,12 +89,12 @@ var _ = Describe("Instantiate one ClusterProfile per resource. Instantiate and d
 		eventTrigger.Spec.OneForEvent = true
 		eventTrigger.Spec.HelmCharts = []configv1beta1.HelmChart{
 			{
-				RepositoryURL:    "https://metallb.github.io/metallb",
-				RepositoryName:   "metallb",
-				ChartName:        "metallb/metallb",
-				ChartVersion:     "0.15.3",
+				RepositoryURL:    metallbRepositoryURL,
+				RepositoryName:   metallbRepositoryName,
+				ChartName:        metallbChartName,
+				ChartVersion:     metallbChartVersion,
 				ReleaseName:      "{{ .Cluster.metadata.name }}",
-				ReleaseNamespace: "{{ .Resource.metadata.namespace }}",
+				ReleaseNamespace: resourceNamespaceTemplate,
 				HelmChartAction:  configv1beta1.HelmChartActionInstall,
 				ValuesFrom: []configv1beta1.ValueFrom{
 					{

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -48,6 +48,14 @@ const (
 	instantiateOk         = "ok"
 	workloadCluster       = "clusterapi-workload"
 	copiedVersion         = "copied-version"
+
+	// metallb is used across fv HelmChart tests: small, fast to fetch/render.
+	metallbRepositoryURL  = "https://metallb.github.io/metallb"
+	metallbRepositoryName = "metallb"
+	metallbChartName      = "metallb/metallb"
+	metallbChartVersion   = "0.15.3"
+
+	resourceNamespaceTemplate = "{{ .Resource.metadata.namespace }}"
 )
 
 // Byf is a simple wrapper around By.


### PR DESCRIPTION
EventTrigger HelmChart and KustomizationRef fields (values, releaseName, path, etc.) are meant to support Go templates so they can be customized per matching resource. Under the hood, before this fix, event-manager instantiated these by serializing the whole HelmChart (or KustomizationRef) struct to JSON, running the JSON text through the template engine, and parsing the result back.

That approach breaks as soon as a template action uses a quoted string as a function argument, which is a completely normal thing to do. for example stripping a suffix from a resource name with `{{ .Resource.metadata.name | replace "-control-plane" "" }}`. JSON-encoding the struct escapes those quotes to \" before the template engine ever sees them, so the parser chokes with an error like unexpected "\\" in operand, and the whole EventTrigger fails to produce a ClusterProfile.

The same pattern also affected destinationCluster templating.

HelmChart, KustomizationRef, and DestinationCluster fields are now instantiated individually, one field at a time, instead of being bundled into a single JSON blob and templated together. Each field's raw template text goes straight into the template engine, so quoted arguments to functions like replace are no longer mangled. This also happens to make it cheaper to instantiate since we don't have to eventually decode a resulting JSON string.

Because each field is now templated independently rathernt, templates that relied on rendering across multiplefields at once, e.g. defining something in one field and expecting it visible to another via shared JSON context, no longer work that way, since there was never a supported mechanism for that and Standalone template expressions within a single field are unaffected and continue to work.