### PR TITLE
feat: Report errors in EventReport Status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.12.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--shard-key="
         - "--capi-onboard-annotation="
         - "--v=5"
-        - "--version=v1.12.0"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/event-manager:v1.12.0
+      - image: docker.io/projectsveltos/event-manager:main
         name: manager

--- a/controllers/eventreport_collection.go
+++ b/controllers/eventreport_collection.go
@@ -496,7 +496,9 @@ func processEventReportsForClusterInAgentlessMode(ctx context.Context, c client.
 		}
 
 		logger.V(logs.LogDebug).Info("processing EventReport")
-		if err := updateAllClusterProfiles(ctx, c, ref, er, eventSourceMap, eventTriggerMap, logger); err == nil {
+		err := updateAllClusterProfiles(ctx, c, ref, er, eventSourceMap, eventTriggerMap, logger)
+		setEventReportFailureMessage(ctx, mgmtClient, er, err, logger)
+		if err == nil {
 			updateEventReportStatus(ctx, mgmtClient, er, logger)
 		} else {
 			retErr = err
@@ -517,6 +519,10 @@ func skipCollecting(ctx context.Context, c client.Client, cluster *corev1.Object
 	}
 	ready, err := clusterproxy.IsClusterReadyToBeConfigured(ctx, c, clusterRef, logger)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(logs.LogDebug).Info("cluster no longer exists, skipping")
+			return true, nil
+		}
 		logger.V(logs.LogDebug).Info("cluster is not ready yet")
 		return true, err
 	}
@@ -528,6 +534,10 @@ func skipCollecting(ctx context.Context, c client.Client, cluster *corev1.Object
 	paused, err := clusterproxy.IsClusterPaused(ctx, c, cluster.Namespace, cluster.Name,
 		clusterproxy.GetClusterType(cluster))
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(logs.LogDebug).Info("cluster no longer exists, skipping")
+			return true, nil
+		}
 		logger.V(logs.LogDebug).Error(err, "failed to verify if cluster is paused")
 		return true, err
 	}
@@ -537,6 +547,23 @@ func skipCollecting(ctx context.Context, c client.Client, cluster *corev1.Object
 	}
 
 	return false, nil
+}
+
+// isClusterInPullMode wraps clusterproxy.IsClusterInPullMode, treating a since-deleted cluster
+// as "skip" rather than an error the caller must abort processing on.
+func isClusterInPullMode(ctx context.Context, c client.Client, cluster *corev1.ObjectReference,
+	logger logr.Logger) (skip, isPullMode bool, err error) {
+
+	isPullMode, err = clusterproxy.IsClusterInPullMode(ctx, c, cluster.Namespace, cluster.Name,
+		clusterproxy.GetClusterType(cluster), logger)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(logs.LogDebug).Info("cluster no longer exists, skipping")
+			return true, false, nil
+		}
+		return false, false, err
+	}
+	return false, isPullMode, nil
 }
 
 func collectAndProcessEventReportsFromCluster(ctx context.Context, c client.Client, cluster *corev1.ObjectReference,
@@ -558,10 +585,12 @@ func collectAndProcessEventReportsFromCluster(ctx context.Context, c client.Clie
 		Kind:       cluster.Kind,
 	}
 
-	isPullMode, err := clusterproxy.IsClusterInPullMode(ctx, c, cluster.Namespace, cluster.Name,
-		clusterproxy.GetClusterType(cluster), logger)
+	skipCluster, isPullMode, err := isClusterInPullMode(ctx, c, cluster, logger)
 	if err != nil {
 		return err
+	}
+	if skipCluster {
+		return nil
 	}
 	if !isPullMode && !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, c, getSveltosNamespace(), version,
 		cluster.Namespace, cluster.Name, clusterproxy.GetClusterType(clusterRef), getAgentInMgmtCluster(), logger) {
@@ -608,53 +637,108 @@ func collectAndProcessEventReportsFromCluster(ctx context.Context, c client.Clie
 			continue
 		}
 
-		reprocessing := firstCollection
-		l := logger.WithValues("eventReport", er.Name)
-		// First update/delete eventReports in managemnent cluster
-		var mgmtClusterEventReport *libsveltosv1beta1.EventReport
-		if !er.DeletionTimestamp.IsZero() {
-			l.V(logs.LogDebug).Info("deleting from management cluster")
-			err = deleteEventReport(ctx, c, cluster, er, l)
-			if err != nil {
-				logger.V(logs.LogInfo).Error(err, "failed to delete EventReport in management cluster")
-				continue
-			}
-			reprocessing = true
-		} else if shouldReprocess(er) {
-			l.V(logs.LogDebug).Info("updating in management cluster")
-			mgmtClusterEventReport, err = updateEventReport(ctx, c, cluster, er, isPullMode, l)
-			if err != nil {
-				l.V(logs.LogInfo).Error(err, "failed to update EventReport in management cluster")
-				continue
-			}
-			reprocessing = true
-		}
-
-		if !reprocessing {
-			continue
-		}
-		l.V(logs.LogDebug).Info("processing EventReport")
-		if getAgentInMgmtCluster() {
-			if mgmtClusterEventReport != nil {
-				// After ClusterProfiles are updated, EventReport status is updated to Processed.
-				// If in agentless mode, the Status of EventReport in the management cluster will be updated.
-				// So set er to current version (update otherwise will fail with object has been modified)
-				er = mgmtClusterEventReport
-			}
-		}
-
-		err = updateAllClusterProfiles(ctx, c, cluster, er, eventSourceMap, eventTriggerMap, l)
-		if err == nil {
-			updateEventReportStatus(ctx, clusterClient, er, l)
-		}
+		processOneEventReport(ctx, c, clusterClient, cluster, er, isPullMode, firstCollection,
+			eventSourceMap, eventTriggerMap, logger)
 	}
 	return nil
 }
 
+// processOneEventReport updates or deletes er's management-cluster copy, then, if it is still
+// relevant, generates ClusterProfile(s) from it and records the outcome. Split out of
+// collectAndProcessEventReportsFromCluster to keep that function's cyclomatic complexity down.
+func processOneEventReport(ctx context.Context, c, clusterClient client.Client, cluster *corev1.ObjectReference,
+	er *libsveltosv1beta1.EventReport, isPullMode, firstCollection bool,
+	eventSourceMap map[string][]*v1beta1.EventTrigger, eventTriggerMap map[string]libsveltosset.Set,
+	logger logr.Logger) {
+
+	reprocessing := firstCollection
+	l := logger.WithValues("eventReport", er.Name)
+	// First update/delete eventReports in managemnent cluster
+	var mgmtClusterEventReport *libsveltosv1beta1.EventReport
+	var err error
+	if !er.DeletionTimestamp.IsZero() {
+		l.V(logs.LogDebug).Info("deleting from management cluster")
+		err = deleteEventReport(ctx, c, cluster, er, l)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to delete EventReport in management cluster")
+			return
+		}
+		reprocessing = true
+	} else if shouldReprocess(er) || firstCollection {
+		// firstCollection also forces a reprocessing pass below (regardless of Phase) to
+		// self-heal after a restart, so the management-cluster copy must be resolved here
+		// too - otherwise that pass has nowhere to record a FailureMessage if it fails.
+		l.V(logs.LogDebug).Info("updating in management cluster")
+		mgmtClusterEventReport, err = updateEventReport(ctx, c, cluster, er, isPullMode, l)
+		if err != nil {
+			l.V(logs.LogInfo).Error(err, "failed to update EventReport in management cluster")
+			return
+		}
+		reprocessing = true
+	}
+
+	if !reprocessing {
+		return
+	}
+	l.V(logs.LogDebug).Info("processing EventReport")
+	if getAgentInMgmtCluster() && mgmtClusterEventReport != nil {
+		// After ClusterProfiles are updated, EventReport status is updated to Processed.
+		// If in agentless mode, the Status of EventReport in the management cluster will be updated.
+		// So set er to current version (update otherwise will fail with object has been modified)
+		er = mgmtClusterEventReport
+	}
+
+	err = updateAllClusterProfiles(ctx, c, cluster, er, eventSourceMap, eventTriggerMap, l)
+	// FailureMessage must land on the management-cluster copy regardless of mode: in
+	// pull mode er and mgmtClusterEventReport are the same object already; in the
+	// default in-cluster-agent mode er is the managed cluster's own object, so
+	// mgmtClusterEventReport (the copy updateEventReport creates/updates in the management
+	// cluster) is the one that needs the write. It's nil only for reports being deleted,
+	// since reprocessing (shouldReprocess || firstCollection) always resolves it otherwise.
+	if mgmtClusterEventReport != nil {
+		setEventReportFailureMessage(ctx, c, mgmtClusterEventReport, err, l)
+	}
+	if err == nil {
+		updateEventReportStatus(ctx, clusterClient, er, l)
+	}
+}
+
+// setEventReportFailureMessage records the outcome of the most recent attempt to generate
+// ClusterProfile(s) from er (processErr, nil on success) on the given EventReport. Callers must
+// pass the management-cluster-resident copy of the EventReport (not the managed-cluster source
+// object used for Phase/CloudEvents bookkeeping in updateEventReportStatus) so the result is
+// visible regardless of which mode the source object lives in. Only writes when the
+// FailureMessage actually changes, so a persistent failure does not generate a Status update on
+// every collection cycle.
+func setEventReportFailureMessage(ctx context.Context, c client.Client, er *libsveltosv1beta1.EventReport,
+	processErr error, logger logr.Logger) {
+
+	var message *string
+	if processErr != nil {
+		m := processErr.Error()
+		message = &m
+	}
+
+	unchanged := (er.Status.FailureMessage == nil) == (message == nil) &&
+		(message == nil || *er.Status.FailureMessage == *message)
+	if unchanged {
+		return
+	}
+
+	er.Status.FailureMessage = message
+	if err := c.Status().Update(ctx, er); err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to update EventReport FailureMessage")
+	}
+}
+
+// updateEventReportStatus updates EventReport Status once ClusterProfile(s) have been
+// successfully generated from it: CloudEvents are reset (once processed, no need to keep them)
+// and Phase is marked Processed.
 func updateEventReportStatus(ctx context.Context, clusterClient client.Client, er *libsveltosv1beta1.EventReport,
 	logger logr.Logger) {
 
 	logger.V(logs.LogDebug).Info("updating EventReport")
+
 	// Update EventReport Status in managed cluster
 	if er.Spec.CloudEvents != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("resetting CloudEvents (%d) in EventReport", len(er.Spec.CloudEvents)))
@@ -674,8 +758,7 @@ func updateEventReportStatus(ctx context.Context, clusterClient client.Client, e
 	}
 	phase := libsveltosv1beta1.ReportProcessed
 	er.Status.Phase = &phase
-	err := clusterClient.Status().Update(ctx, er)
-	if err != nil {
+	if err := clusterClient.Status().Update(ctx, er); err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to update EventReport in managed cluster")
 	}
 }

--- a/controllers/eventreport_collection_test.go
+++ b/controllers/eventreport_collection_test.go
@@ -18,6 +18,7 @@ package controllers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -126,6 +127,148 @@ var _ = Describe("EventSource Deployer", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
+
+	It("setEventReportFailureMessage records a failure, skips an unchanged write, then clears on success", func() {
+		eventReport := getEventReport(randomString(), randomString(), randomString())
+
+		initObjects := []client.Object{
+			eventReport,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
+			WithObjects(initObjects...).Build()
+
+		currentEventReport := &libsveltosv1beta1.EventReport{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+
+		processingErr := errors.New(randomString())
+		controllers.SetEventReportFailureMessage(context.TODO(), c, currentEventReport, processingErr, logger)
+
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+		Expect(currentEventReport.Status.FailureMessage).ToNot(BeNil())
+		Expect(*currentEventReport.Status.FailureMessage).To(Equal(processingErr.Error()))
+
+		resourceVersionAfterFailure := currentEventReport.ResourceVersion
+
+		// Same failure message again: FailureMessage is unchanged so no Status update
+		// (and no api-server write) should happen.
+		controllers.SetEventReportFailureMessage(context.TODO(), c, currentEventReport, processingErr, logger)
+
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+		Expect(currentEventReport.ResourceVersion).To(Equal(resourceVersionAfterFailure))
+
+		// Success (nil error) clears FailureMessage
+		controllers.SetEventReportFailureMessage(context.TODO(), c, currentEventReport, nil, logger)
+
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+		Expect(currentEventReport.Status.FailureMessage).To(BeNil())
+	})
+
+	It("updateEventReportStatus marks the EventReport as Processed", func() {
+		eventReport := getEventReport(randomString(), randomString(), randomString())
+
+		initObjects := []client.Object{
+			eventReport,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
+			WithObjects(initObjects...).Build()
+
+		currentEventReport := &libsveltosv1beta1.EventReport{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+
+		controllers.UpdateEventReportStatus(context.TODO(), c, currentEventReport, logger)
+
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+			currentEventReport)).To(Succeed())
+		Expect(currentEventReport.Status.Phase).ToNot(BeNil())
+		Expect(*currentEventReport.Status.Phase).To(Equal(libsveltosv1beta1.ReportProcessed))
+	})
+
+	It("skipCollecting skips without error when cluster no longer exists", func() {
+		clusterRef := &corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		skip, err := controllers.SkipCollecting(context.TODO(), c, clusterRef, logger)
+		Expect(err).To(BeNil())
+		Expect(skip).To(BeTrue())
+	})
+
+	It("processOneEventReport records a FailureMessage when firstCollection forces reprocessing of an already-Processed EventReport",
+		func() {
+			// Simulates an event-manager restart: the EventReport was already marked Processed
+			// before the restart, so shouldReprocess alone would skip it. firstCollection must
+			// still force one reprocessing attempt, and if that attempt fails (here: no matching
+			// resources yet, so updateClusterProfiles returns the zero-match confirmation error),
+			// the failure must land on EventReport.Status.FailureMessage rather than being dropped.
+			controllers.SetAgentInMgmtCluster(false)
+			controllers.ResetZeroMatchCounters()
+
+			clusterRef := &corev1.ObjectReference{
+				Namespace:  randomString(),
+				Name:       randomString(),
+				Kind:       libsveltosv1beta1.SveltosClusterKind,
+				APIVersion: libsveltosv1beta1.GroupVersion.String(),
+			}
+
+			eventSourceName := randomString()
+			eventTrigger := &v1beta1.EventTrigger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomString(),
+				},
+				Spec: v1beta1.EventTriggerSpec{
+					EventSourceName: eventSourceName,
+				},
+				Status: v1beta1.EventTriggerStatus{
+					MatchingClusterRefs: []corev1.ObjectReference{*clusterRef},
+				},
+			}
+
+			eventReport := getEventReport(eventSourceName, clusterRef.Namespace, clusterRef.Name)
+			phase := libsveltosv1beta1.ReportProcessed
+			eventReport.Status.Phase = &phase
+
+			initObjects := []client.Object{eventTrigger, eventReport}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
+				WithObjects(initObjects...).Build()
+
+			currentEventReport := &libsveltosv1beta1.EventReport{}
+			Expect(c.Get(context.TODO(),
+				types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+				currentEventReport)).To(Succeed())
+
+			eventSourceMap := map[string][]*v1beta1.EventTrigger{
+				eventSourceName: {eventTrigger},
+			}
+			eventTriggerMap := controllers.BuildEventTriggersForClusterMap(
+				&v1beta1.EventTriggerList{Items: []v1beta1.EventTrigger{*eventTrigger}})
+
+			controllers.ProcessOneEventReport(context.TODO(), c, c, clusterRef, currentEventReport,
+				true, true, eventSourceMap, eventTriggerMap, logger) // isPullMode=true, firstCollection=true
+
+			Expect(c.Get(context.TODO(),
+				types.NamespacedName{Namespace: eventReport.Namespace, Name: eventReport.Name},
+				currentEventReport)).To(Succeed())
+			Expect(currentEventReport.Status.FailureMessage).ToNot(BeNil())
+			Expect(*currentEventReport.Status.FailureMessage).To(ContainSubstring("waiting for confirmation"))
+		})
 
 	It("removeEventReports deletes all EventReport for a given EventSource instance", func() {
 		eventReport1 := getEventReport(eventSource.Name, randomString(), randomString())

--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -1383,7 +1383,8 @@ func updateClusterProfiles(ctx context.Context, c client.Client, clusterNamespac
 		if count < zeroMatchThreshold {
 			logger.V(logs.LogInfo).Info("EventReport has no matching resources, waiting for confirmation",
 				"count", count, "threshold", zeroMatchThreshold)
-			return fmt.Errorf("EventReport %s/%s shows no matches (%d/%d), requeuing",
+			return fmt.Errorf("EventReport %s/%s has no matching resources: waiting for confirmation before removing "+
+				"ClusterProfiles (%d/%d consecutive empty reports observed)",
 				er.Namespace, er.Name, count, zeroMatchThreshold)
 		}
 		logger.V(logs.LogDebug).Info("EventReport has no matching resources confirmed, removing ClusterProfiles",

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -28,6 +28,10 @@ var (
 	CollectAndProcessAllEventReports         = collectAndProcessAllEventReports
 	DeleteEventReport                        = deleteEventReport
 	ProcessEventTriggerForCluster            = processEventTriggerForCluster
+	UpdateEventReportStatus                  = updateEventReportStatus
+	SetEventReportFailureMessage             = setEventReportFailureMessage
+	SkipCollecting                           = skipCollecting
+	ProcessOneEventReport                    = processOneEventReport
 )
 
 var (

--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -46,7 +46,10 @@ func EventReportPredicates(logger logr.Logger) predicate.Funcs {
 				return true
 			}
 
-			if !reflect.DeepEqual(oldER, newER) {
+			// return true if EventReport Spec has changed. Status is written by event-manager
+			// itself (Phase, FailureMessage) so it must not be compared here, or every such
+			// write would spuriously requeue the associated EventTriggers.
+			if !reflect.DeepEqual(oldER.Spec, newER.Spec) {
 				log.V(logs.LogVerbose).Info("EventReport Spec changed")
 				return true
 			}

--- a/controllers/predicates_test.go
+++ b/controllers/predicates_test.go
@@ -129,6 +129,46 @@ var _ = Describe("EventTrigger Predicates: EventReportPredicates", func() {
 		result := hcrPredicate.Update(e)
 		Expect(result).To(BeFalse())
 	})
+
+	It("Update does not reprocess when only Status changes", func() {
+		hcrPredicate := controllers.EventReportPredicates(logger)
+
+		eventReport.Spec = libsveltosv1beta1.EventReportSpec{
+			MatchingResources: []corev1.ObjectReference{
+				{
+					Kind:       randomString(),
+					APIVersion: randomString(),
+					Name:       randomString(),
+					Namespace:  randomString(),
+				},
+			},
+		}
+		phase := libsveltosv1beta1.ReportProcessed
+		eventReport.Status = libsveltosv1beta1.EventReportStatus{
+			Phase: &phase,
+		}
+
+		oldEventReport := &libsveltosv1beta1.EventReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      eventReport.Name,
+				Namespace: eventReport.Namespace,
+			},
+			Spec: eventReport.Spec,
+			// Status differs from eventReport (empty vs Processed with a FailureMessage),
+			// Spec does not: event-manager itself writes Status and must not requeue
+			// EventTriggers as a result.
+		}
+		failureMessage := randomString()
+		oldEventReport.Status.FailureMessage = &failureMessage
+
+		e := event.UpdateEvent{
+			ObjectNew: eventReport,
+			ObjectOld: oldEventReport,
+		}
+
+		result := hcrPredicate.Update(e)
+		Expect(result).To(BeFalse())
+	})
 })
 
 var _ = Describe("EventTrigger Predicates: EventSourcePredicates", func() {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v1.12.0
-	github.com/projectsveltos/libsveltos v1.12.0
+	github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectsveltos/addon-controller v1.12.0 h1:CVCLmUrRytucRYNjGAIua68aR1lqd6C/pNSKfzjH8CA=
 github.com/projectsveltos/addon-controller v1.12.0/go.mod h1:ummIcdJVlM3n7hAFTNirdtbtQ/Lu19fKxsSfAuvtzHk=
-github.com/projectsveltos/libsveltos v1.12.0 h1:xQfo/AEh3vVRbfWVazpsgBoRgBG5vzm/sJmXp5YrUEg=
-github.com/projectsveltos/libsveltos v1.12.0/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599 h1:M6NPrOphh8F5+ARgyvKXMmL41yB875dzkWh5PprptBI=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,7 +23,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -40,7 +40,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/event-manager:v1.12.0
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -2608,7 +2608,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -2625,7 +2625,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/event-manager:v1.12.0
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/fv/eventreport_failure_test.go
+++ b/test/fv/eventreport_failure_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/event-manager/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+var _ = Describe("EventReport failure reporting", func() {
+	const (
+		namePrefix = "eventreport-failure-"
+	)
+
+	It("Records a FailureMessage on EventReport.Status when ClusterProfile generation fails, clears it once fixed",
+		Label("FV", "PULLMODE"), func() {
+
+			serviceNamespace := randomString()
+
+			eventSource := libsveltosv1beta1.EventSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: randomString(),
+				},
+				Spec: libsveltosv1beta1.EventSourceSpec{
+					ResourceSelectors: []libsveltosv1beta1.ResourceSelector{
+						{
+							Group:     "",
+							Version:   coreV1Version,
+							Kind:      serviceKind,
+							Namespace: serviceNamespace,
+							Evaluate:  serviceLuaScript,
+						},
+					},
+					// Full resource data (not just the object reference) must be collected for
+					// the ConfigMap template below to resolve .Resource.metadata.name.
+					CollectResources: true,
+				},
+			}
+			Byf("Create a EventSource %s matching Services in namespace: %s",
+				eventSource.Name, serviceNamespace)
+			Expect(k8sClient.Create(context.TODO(), &eventSource)).To(Succeed())
+
+			// generatorConfigMapName is intentionally never created before the EventTrigger is:
+			// ConfigMapGenerator with Optional unset (false) makes instantiateResourceFromGenerator
+			// fail deterministically with "referenced resource ... does not exist yet"
+			// (eventtrigger_deployer.go), exercising EventReport.Status.FailureMessage without
+			// depending on Go template parsing/execution behavior.
+			generatorConfigMapName := namePrefix + randomString()
+
+			eventTrigger := getEventTrigger(namePrefix, eventSource.Name,
+				map[string]string{key: value}, nil)
+			// OneForEvent selects the per-resource template context (.Resource); the default
+			// (false) uses the plural .Resources instead, which the ConfigMap template below
+			// does not use.
+			eventTrigger.Spec.OneForEvent = true
+			eventTrigger.Spec.ConfigMapGenerator = []v1beta1.GeneratorReference{
+				{
+					Namespace:                      defaultNamespace,
+					Name:                           generatorConfigMapName,
+					InstantiatedResourceNameFormat: "{{ .Cluster.metadata.name }}-generated",
+				},
+			}
+			Byf("Create a EventTrigger %s referencing EventSource %s", eventTrigger.Name, eventSource.Name)
+			Expect(k8sClient.Create(context.TODO(), eventTrigger)).To(Succeed())
+
+			Byf("Getting client to access the workload cluster")
+			workloadClient, err := getKindWorkloadClusterKubeconfig()
+			Expect(err).To(BeNil())
+			Expect(workloadClient).ToNot(BeNil())
+
+			eventReportName := getEventReportName(eventSource.Name)
+
+			Byf("Verifying EventReport %s is present in the management cluster", eventReportName)
+			Eventually(func() error {
+				currentEventReport := &libsveltosv1beta1.EventReport{}
+				return k8sClient.Get(context.TODO(),
+					types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: eventReportName},
+					currentEventReport)
+			}, timeout, pollingInterval).Should(BeNil())
+
+			createNamespaceAndService(workloadClient, serviceNamespace)
+
+			Byf("Verifying EventReport %s Status.FailureMessage is set in the management cluster", eventReportName)
+			Eventually(func() bool {
+				currentEventReport := &libsveltosv1beta1.EventReport{}
+				err = k8sClient.Get(context.TODO(),
+					types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: eventReportName},
+					currentEventReport)
+				if err != nil {
+					return false
+				}
+				return currentEventReport.Status.FailureMessage != nil
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			By("Verifying no ClusterProfile has been created while generation keeps failing")
+			listOptions := []client.ListOption{
+				client.MatchingLabels(getInstantiatedObjectLabels(eventTrigger.Name)),
+			}
+			clusterProfileList := &configv1beta1.ClusterProfileList{}
+			Expect(k8sClient.List(context.TODO(), clusterProfileList, listOptions...)).To(Succeed())
+			Expect(len(clusterProfileList.Items)).To(BeZero())
+
+			Byf("Creating the referenced ConfigMap %s/%s so generation can succeed",
+				defaultNamespace, generatorConfigMapName)
+			generatorConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      generatorConfigMapName,
+					Annotations: map[string]string{
+						instantiateAnnotation: instantiateOk,
+					},
+				},
+				Data: map[string]string{
+					"key": "{{ .Resource.metadata.name }}", //nolint: goconst // just a test
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), generatorConfigMap)).To(Succeed())
+
+			Byf("Verifying EventReport %s Status.FailureMessage is cleared in the management cluster", eventReportName)
+			Eventually(func() bool {
+				currentEventReport := &libsveltosv1beta1.EventReport{}
+				err = k8sClient.Get(context.TODO(),
+					types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: eventReportName},
+					currentEventReport)
+				if err != nil {
+					return false
+				}
+				return currentEventReport.Status.FailureMessage == nil
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			By("Verifying ClusterProfile has been created now that generation succeeds")
+			Eventually(func() bool {
+				clusterProfileList := &configv1beta1.ClusterProfileList{}
+				err = k8sClient.List(context.TODO(), clusterProfileList, listOptions...)
+				if err != nil {
+					return false
+				}
+				return len(clusterProfileList.Items) == 1
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Byf("Deleting EventTrigger %s", eventTrigger.Name)
+			currentEventTrigger := &v1beta1.EventTrigger{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: eventTrigger.Name},
+				currentEventTrigger)).To(Succeed())
+			Expect(k8sClient.Delete(context.TODO(), currentEventTrigger)).To(Succeed())
+
+			verifyClusterProfilesAreGone(eventTrigger.Name)
+
+			Byf("Deleting EventSource %s", eventSource.Name)
+			currentEventSource := &libsveltosv1beta1.EventSource{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: eventSource.Name},
+				currentEventSource)).To(Succeed())
+			Expect(k8sClient.Delete(context.TODO(), currentEventSource)).To(Succeed())
+
+			Byf("Deleting ConfigMap %s/%s", generatorConfigMap.Namespace, generatorConfigMap.Name)
+			Expect(k8sClient.Delete(context.TODO(), generatorConfigMap)).To(Succeed())
+		})
+})

--- a/test/fv/profile_before_resources_test.go
+++ b/test/fv/profile_before_resources_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ClusterProfile deletion precedes referenced resource cleanup",
 					},
 				},
 				Data: map[string]string{
-					"namespace": "{{ .Resource.metadata.name }}",
+					"namespace": "{{ .Resource.metadata.name }}", //nolint: goconst // just a test
 				},
 			}
 			Byf("Create template ConfigMap %s/%s annotated for instantiation",

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:62900d55e4a3d818150e0bc46cd1657219ba0614960acecc0f3b805baba3c74d
+        image: docker.io/projectsveltos/sveltos-applier@sha256:39cb8103d171160155306324f5781b991074edf2389ea443ba5a99f58f0f669b
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/sveltos-agent.yaml
+++ b/test/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -203,7 +203,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent:v1.12.0
+        image: docker.io/projectsveltos/sveltos-agent:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When an EventReport is processed, event-manager creates one or more ClusterProfile. If an error occurs, the error was only visible in event-manager logs.

This PR makes sure the error is reported in the EventReport status.