### PR TITLE
opt: Cache managed-cluster clients via libsveltos clustercache

### DIFF
--- a/controllers/eventreport.go
+++ b/controllers/eventreport.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/projectsveltos/event-manager/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/mgmtagent"
 )
@@ -54,7 +54,7 @@ func getEventReportClient(ctx context.Context, clusterNamespace, clusterName str
 	// ResourceSummary is a Sveltos resource created in managed clusters.
 	// Sveltos resources are always created using cluster-admin so that admin does not need to be
 	// given such permissions.
-	return clusterproxy.GetKubernetesClient(ctx, getManagementClusterClient(),
+	return clustercache.GetManager().GetKubernetesClient(ctx, getManagementClusterClient(),
 		clusterNamespace, clusterName, "", "", clusterType, logger)
 }
 

--- a/controllers/eventreport_collection.go
+++ b/controllers/eventreport_collection.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/projectsveltos/event-manager/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
@@ -734,6 +735,8 @@ func collectAndProcessEventReportsFromCluster(ctx context.Context, c client.Clie
 	clusterClient, err := getEventReportClient(ctx, cluster.Namespace, cluster.Name,
 		clusterproxy.GetClusterType(clusterRef), isPullMode, logger)
 	if err != nil {
+		clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			clusterproxy.GetClusterType(clusterRef), err)
 		return err
 	}
 

--- a/controllers/eventtrigger_deployer.go
+++ b/controllers/eventtrigger_deployer.go
@@ -53,6 +53,7 @@ import (
 	"github.com/projectsveltos/event-manager/api/v1beta1"
 	"github.com/projectsveltos/event-manager/pkg/scope"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 	"github.com/projectsveltos/libsveltos/lib/funcmap"
@@ -651,6 +652,9 @@ func (r *EventTriggerReconciler) proceedProcessingEventTrigger(ctx context.Conte
 		if result.Err != nil {
 			errorMessage := result.Err.Error()
 			clusterInfo.FailureMessage = &errorMessage
+
+			clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), result.Err)
 		}
 
 		if *deployerStatus == libsveltosv1beta1.SveltosStatusProvisioned {
@@ -865,6 +869,9 @@ func (r *EventTriggerReconciler) removeEventTrigger(ctx context.Context, eScope 
 		if result.Err != nil {
 			failureMessage := result.Err.Error()
 			clusterInfo.FailureMessage = &failureMessage
+
+			clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), result.Err)
 		}
 	} else {
 		logger.V(logs.LogDebug).Info("no result is available. mark status as removing")
@@ -1117,13 +1124,15 @@ func deployEventSource(ctx context.Context, c client.Client,
 			eventTrigger, currentEventSource, logger)
 	}
 
-	// If sveltos-agent is deployed to the managed cluster, deply EventSource there
+	// If sveltos-agent is deployed to the managed cluster, deploy EventSource there.
 	var remoteClient client.Client
-	remoteClient, err = clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
-		"", "", clusterType, logger)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
-		return err
+	if !isPullMode {
+		remoteClient, err = clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+			"", "", clusterType, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
+			return err
+		}
 	}
 
 	// classifier installs sveltos-agent and CRDs it needs, including
@@ -1298,7 +1307,7 @@ func proceedRemovingStaleEventSources(ctx context.Context, c client.Client,
 	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
 	eventTrigger *v1beta1.EventTrigger, removeAll bool, logger logr.Logger) error {
 
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+	remoteClient, err := clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get managed cluster client")
@@ -3737,7 +3746,7 @@ func (r *EventTriggerReconciler) resetEventReportStatus(ctx context.Context,
 	} else {
 		eventReportName = eventTrigger.Spec.EventSourceName
 		eventReportNamespace = sveltosNamespace
-		kubernetesClient, err = clusterproxy.GetKubernetesClient(ctx, r.Client, clusterRef.Namespace,
+		kubernetesClient, err = clustercache.GetManager().GetKubernetesClient(ctx, r.Client, clusterRef.Namespace,
 			clusterRef.Name, "", "", clusterType, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to get client")

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/addon-controller v1.12.0
-	github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599
+	github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/projectsveltos/addon-controller v1.12.0 h1:CVCLmUrRytucRYNjGAIua68aR1lqd6C/pNSKfzjH8CA=
 github.com/projectsveltos/addon-controller v1.12.0/go.mod h1:ummIcdJVlM3n7hAFTNirdtbtQ/Lu19fKxsSfAuvtzHk=
-github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599 h1:M6NPrOphh8F5+ARgyvKXMmL41yB875dzkWh5PprptBI=
-github.com/projectsveltos/libsveltos v1.12.1-0.20260710130013-eceb69a88599/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087 h1:uOHm6bX9SKfeR6htJHrg5pXK6d2fKmdeRrs9dkIvnkA=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:39cb8103d171160155306324f5781b991074edf2389ea443ba5a99f58f0f669b
+        image: docker.io/projectsveltos/sveltos-applier@sha256:c7e615f9eeb90362365902a6a38305b87f760c70b3e1a91c251acf2c12fb3c79
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
event-manager previously called clusterproxy.GetKubernetesClient directly, which builds a new rest.Config, discovery client, and RESTMapper via a live discovery round-trip on every call. Switches to the shared lib/clustercache.GetManager() from libsveltos so these are cached like addon-controller's are.

Also calls InvalidateOnAuthError wherever a deploy/undeploy result or a periodic EventReport collection comes back with an error, so a cached client gets evicted as soon as the API server starts rejecting credentials (401/403) instead of only on TTL expiry or cluster deletion.